### PR TITLE
Change name "Active" to "Graduated".

### DIFF
--- a/criteria-for-promoted-release.md
+++ b/criteria-for-promoted-release.md
@@ -10,7 +10,7 @@ nav_order: 4
 Prior to bringing a project to the TSC for a vote on granting a Promoted
 Release, a project must fulfill the following criteria:
 
-1.  Project has reached [Active](./project-lifecycle.md#active) status (the processes and community are
+1.  Project has reached [Graduated](./project-lifecycle.md#graduated) status (the processes and community are
     mature)
 2.  The release features substantially fulfill the project\'s charter
 3.  The release satisfies criteria defined by the project itself. All

--- a/project-incubation-exit.md
+++ b/project-incubation-exit.md
@@ -12,27 +12,27 @@ nav_order: 5
 Hyperledger has defined a [lifecycle](./project-lifecycle.md) for its
 projects but this definition does not specify in any detail what it
 takes for a project to be able to transition from the
-*Incubation* phase to the *Active* phase.
+*Incubation* phase to the *Graduated* phase.
 
 This document is meant to fill this gap by defining a set of criteria to
 be considered before moving a project from *Incubation*
-to *Active*.
+to *Graduated*.
 
-It is important to note that *Active* in this case refers to
+It is important to note that *Graduated* in this case refers to
 the project itself rather than its product and it is therefore more
 about the maturity of process than the maturity of the product or
 General Availability (GA).
 
 For this reason this document defines two sets of exit criteria. The
 first one is made of requirements expected to be met by all projects
-before moving to *Active*. The second set lists examples of
+before moving to *Graduated*. The second set lists examples of
 additional requirements typically defined at the onset of the project as
 goals to be met to exit *Incubation*. These are expected to be documented
 in a [Proposal for a Hyperledger Improvement Project (HIP)](https://hyperledger.github.io/hyperledger-hip/)
 Because not all projects have the same goals, the importance of each
 criteria and the exact definition of this second set of criteria may
 vary from one project to another. Ultimately the TSC is responsible for
-determining whether a project deserves to move to *Active* or
+determining whether a project deserves to move to *Graduated* or
 not and this decision does not need to be solely based on these exit
 criteria. The purpose of these exit criteria is to help the TSC in its
 decision process by informing its members of key aspects of the project.
@@ -80,7 +80,7 @@ decision process by informing its members of key aspects of the project.
     -   Compatibility with other Hyperledger projects
 
         Where applicable, the project should be compatible with other
-        active projects.
+        *Graduated* projects.
 
     -   Release numbering: the project should use the Hyperledger
         standard [release taxonomy](./release-taxonomy.md), once that is agreed upon.

--- a/project-lifecycle.md
+++ b/project-lifecycle.md
@@ -31,8 +31,7 @@ Projects are in one of five possible states:
 
 -   [*Proposal*](#proposal)
 -   [*Incubation*](#incubation)
--   [*Active*](#active)
--   [*Promoted Release*](#promoted-release)
+-   [*Graduated*](#graduated)
 -   [*Deprecated*](#deprecated)
 -   [*End of Life*](#end-of-life)
 
@@ -69,35 +68,25 @@ Projects in *Incubation* may overlap with one another.
 Entering *Incubation* is meant to be fairly easy to allow for
 community exploration of different ideas.
 
-Once a project qualifies to be declared *Active*, the
+Once a project qualifies to be declared *Graduated*, the
 *project*\'s maintainers can then vote to request a graduation
 review by the TSC.
 
 Entering *Incubation* does not guarantee that the project will
-eventually get to *Active* state. Projects may never get
-to *Active* state.
+eventually get to *Graduated* state. Projects may never get
+to *Graduated* state.
 
 Projects seeking to graduate from *Incubation* must meet
 the criteria defined in the 
 [Incubation Exit Criteria](./project-incubation-exit.md) document.
 
-# Active
+# Graduated
+
+(Formerly called 'Active') <a id="active"></a>
 
 Projects that have successfully exited the *Incubation* phase
-are in the *Active* phase. *Active* projects are eligible
-for [*Promoted Releases*](#promoted-release).
-
-# Promoted Release
-
-A project\'s maintainers seeking to publish a *Promoted
-Release* (see Hyperledger\'s use of [semver](./release-taxonomy.md#1);
-also, [semver.org](https://semver.org)) must seek approval of the TSC
-whether in Active or Incubation status as defined above. While it is
-expected that most projects will have reached an *Active* status by
-the time their maintainers seek to announce a *Promoted Release*, the
-TSC may approve such requests also in cases where the project is still
-in *Incubation* status, should the TSC believe that the project\'s code is
-sufficiently mature.
+are in the *Graduated* phase. *Graduated* projects are eligible
+for [*Promoted Releases*](./criteria-for-promoted-release.md).
 
 # Deprecated
 
@@ -118,3 +107,4 @@ period, the project will be labeled *End of Life*.
 # End of Life
 
 A project that is no longer actively developed or maintained.
+


### PR DESCRIPTION
This also removes the section on Promoted Release because it is not one of the states a project
can be in.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>