### PR TITLE
Maintainer and Repository Inactivity Policy

### DIFF
--- a/inactivity.md
+++ b/inactivity.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Maintainer and Repository Inactivity
+nav_order: 6
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Inactivity Policies
+
+As part of the normal lifecycle of a project codebases and maintainers come and go. This document formalizes a Hyperledger wide policy for moving maintainers to emeritus status when a project does not have an explicit policy of their own, and the responsibilities of the Technical Steering Committee (TSC), Hyperledger Foundation staff, and maintainers in this process.
+
+## Maintainer Inactivity
+
+This policy applies to projects that do not have an explicit maintainer inactivity policy. Where a project has an established and functioning policy, only that project's policy will apply.
+
+Hyperledger very much appreciates the contributions of all maintainers but removing write privileges is in the interest of an orderly and secure project.
+
+Activity can be code contributions, code reviews, issue reporting, or any other such activity trackable by GitHub attributed to a Hyperledger repository.
+
+When a maintainer has not had any activity in a particular project for three months they will receive a notification informing them of the inactivity policies. The means and manner of notification (email, github mentions, etc.) will be at the discretion of the TSC Chair or who the TSC Chair designates. 
+
+When a maintainer has not had any activity in a particular project for six months a proposal will be opened up to move the maintainer from active status to emeritus status. A member of the TSC or a Hyperledger staff member will open this proposal. Any permissions to approve pull requests or commit code and any other such privileges associated with maintainer status will be removed.
+
+The proposal will be in the form of a pull request (PR) to the relevant project repositories updating their maintainer lists. The inactive maintainer will be notified of this via an "at" @ mention in the PR. The PR will be open for at least one week to allow time for the project and maintainer to comment.
+
+Inactive maintainers who express an intent to continue contributing may request a three-month extension. This request shall be made in the pull request updating their active maintainer status. Typically, only one such extension will be granted.
+
+Maintainers who have been moved to emeritus status may return to active status when their activity within the project resumes and the current maintainers of the project approve their reactivation.
+
+A Hyperledger Foundation staff member will provide a report (or maintain an automated means to generate a report) of the most recent GitHub tracked actions for contributors at regular intervals to the TSC.  It will be the TSC's responsibility to act on the data.

--- a/index.md
+++ b/index.md
@@ -14,6 +14,7 @@ Governing Documents:
 * [Project Incubation Exit Criteria](./project-incubation-exit.md)
 * [Project Lifecycle](./project-lifecycle.md)
 * [Release Taxonomy](./release-taxonomy.md)
+* [Maintainer and Repository Inactivity](./inactivity.md)
 
 Guidelines:
 


### PR DESCRIPTION
Establish policies for when a maintainer stops contributing and when
repositories stop receiving contributions.

Fixes #32 

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>