### PR TITLE
Propose security related mandates for graduation

### DIFF
--- a/project-incubation-exit.md
+++ b/project-incubation-exit.md
@@ -96,6 +96,16 @@ decision process by informing its members of key aspects of the project.
     -   Project is set up with Continuous Integration
     -   All project repos have implemented the [common repository structure](./repository-structure.md)
 
+-   Security
+
+    The project must identify key contact points to address
+    security related questions and concerns.
+    Some of the other responsibilities for them include:
+
+    -   Address automated alerts, such as depend-a-bot, in a timely manner.
+
+    -   Participate in Hyperledger Foundation wide security discussions.
+
 -   CII Badge
 
     A team seeking to graduate from *Incubation* shall have started the


### PR DESCRIPTION
1. Introduce a new security sub-section as a criteria for
graduating a project.
2. Add responsibilities for each project team to have healthy
project from security standpoint in Hyperledger Foundation.