### PR TITLE
Updates to the Maintainers Guidelines and list of Maintainer Tasks

### DIFF
--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -6,60 +6,97 @@ grand_parent: Hyperledger TOC
 nav_order: 2
 ---
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
-# Introduction
-All Hyperledger projects MUST have a `MAINTAINERS` file (`MAINTAINERS.md` or `MAINTAINERS.rst`) at the top-level directory of the source code. This document will provide guidelines on what should be included in the `MAINTAINERS` file.
 
-# Guidelines
-## List of Project Maintainers
-The first thing that MUST be included in the `MAINTAINERS` file is a list of the project's maintainers, both active and emeritus.
+## Introduction
 
-It is recommended that the lists be sorted alphabetically and contain the maintainers name, GitHub ID, LFID, Chat ID, Email, Company Affiliation, and Scope.
+All Hyperledger repositories MUST have a `MAINTAINERS` file (`MAINTAINERS.md` or `MAINTAINERS.rst`) at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](SAMPLE-MAINTAINERS.md) can be used as a template by projects creating a new repository.
 
-**NOTES:**
-* There MUST be at least one reliable mechanism to contact the maintainer (either chat ID or email).
-* Scope is dependent on the project and may not exist for a given project. Scope could be the whole project, a specific repository, specific directories in a repository, or high-level description of responsibility (e.g., Documentation).
+The Hyperledger Foundation GitHub organization administrators **SHOULD** periodically send out notifications about missing `MAINTAINERS` files.
 
-The following shows the suggested format for the information:
+The following provides guidelines and suggested content to include in the `MAINTAINERS` file.
+
+## Maintainer Scopes and GitHub Roles
+
+Becoming a Maintainer for a repository implies being granted special privileges within that repository to do the additional tasks required of a Maintainer. In most cases, the additional privileges are implemented
+by giving maintainers one of the elevated [GitHub roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization) within the repository.
+
+In most repositories, only the "Maintain" GitHub role is used. It is given to all repository Maintainers.
+
+In some repositories, the maintainers may define a list of "scopes" and each Maintainer given one or more of the designated scopes:
+
+- In rare cases, Maintainers in a repository may request that the Hyperledger Foundation GitHub organization administrators enable designating some Maintainers with different GitHub roles, such as "Admin" (more capable than "Maintain") or "Triage" (less capable than "Maintain").
+  - Each elevated GitHub role needed in a repository requires the Hyperledger Foundation GitHub organization administrators to create and maintain an additional GitHub Team.
+  - The Hyperledger Foundation GitHub organization administrators manage a team per Hyperledger Project that includes all contributors to the project. That team is given the "Read" GitHub role in all project repositories. This team need not be documented in the "MAINTAINERS" file.
+- Maintainers **MAY** define Maintainers scope within a repository don't require
+  elevated GitHub privileges. For example, a scope might include hosting
+  community meetings, or contributing to the Hyperledger Project's Quarterly
+  report.
+
+If there is more than the single "Maintainer" scope used in a repository, there **MUST** be a list of the repository specific scopes in the MAINTAINERS file. The list must include the scope name, the definition of the scope, and if applicable, the related GitHub Role and Team for the scope.
+
+| Scope | Definition | GitHub Role | GitHub Team |
+| ----- | ---------- | ----------- | ----------- |
+|       |            |             |             |
+
+## List of Repository Maintainers
+
+Lists of active and emeritus maintainers MUST be included in the `MAINTAINERS` file.
+
+Changes to the maintainers lists MUST be made via Pull Requests. Once a new `MAINTAINERS` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
+
+It is recommended that the lists be sorted alphabetically and contain at least the maintainers name and GitHub ID. If useful, other columns may be added to the table, such as LFID, Discord ID, Email, and Company Affiliation.
+
+A "Scope" column **MUST** be included if there is more than one scope defined in the repository.
+
+The following shows a suggested format for the information:
 
 **Active Maintainers**
 
-| Maintainer | GitHub ID | LFID | Chat ID | Email | Company Affiliation | Scope |
-| ---------- | --------- | ---- | ------- | ----- | ------------------- | ----- |
-|            |           |      |         |       |                     |       |
+| Maintainer | GitHub ID | Scope |
+| ---------- | --------- | ----- |
+|            |           |       |
 
 **Emeritus Maintainers**
 
-| Maintainer | GitHub ID | LFID | Chat ID | Email | Company Affiliation | Scope |
-| ---------- | --------- | ---- | ------- | ----- | ------------------- | ----- |
-|            |           |      |         |       |                     |       |
+| Maintainer | GitHub ID | Scope |
+| ---------- | --------- | ----- |
+|            |           |       |
 
 ## What Does Being a Maintainer Entail
-The `MAINTAINERS` file SHOULD contain information about the different types of maintainers that exist (whole project, repo, part of repo) and what their duties are (e.g., maintainers calls, quarterly reports, code reviews, issue cleansing).
+
+The `MAINTAINERS` file **SHOULD** contain information about the different
+maintainer scopes, and for each, the maintainers duties (e.g., maintainers
+calls, quarterly reports, code reviews, issue cleansing). See the [Sample
+Maintainers](SAMPLE-MAINTAINERS.md) for an example of what to include in this
+section for an open source software project. Feel free to evolve that text to
+match the needs of the repository and project.
+
+If the repository is for a community specification, or other governance or
+documentation purpose, the tasks of the Maintainers (often called "Editors"
+in such cases) might be different than for Maintainers of an open source code
+project. The Maintainer role is more about approving and merging pull requests
+that reflect the agreement of the community, as opposed to code related metrics
+(quality, fit for purpose, tests, etc.). In some cases, a GOVERNANCE.md file
+[like this](https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md) might further define the duties of the maintainers.
 
 ## How to Become a Maintainer
-The `MAINTAINERS` file SHOULD contain information about how to become a maintainer for the project. This section SHOULD list specific information about what is required. Information that SHOULD be included in this section:
 
-* What is required before someone can be considered to become a maintainer
-* Consider whether there should be different requirements based on the scope (whole project, repo, part of repo) of maintainership
-* Whether sponsorship by an existing maintainer is required
-* How maintainers are proposed to the community. A number of our projects require that a PR be done against the `MAINTAINERS` file to make this proposal
-* How many maintainers must approve the proposed maintainer. This should include information about what happens if someone vetoes the proposal
-* How long the existing maintainers have to respond to the proposal
+The `MAINTAINERS` file **SHOULD** contain information about how to become a maintainer for the project. This section **SHOULD** list specific information about what is required. Information that **SHOULD** be included in this section:
+
+* What is required before someone can be considered to become a maintainer.
+  * Include a statement on how an emeritus maintainer can be changed to active again.
+* Consider whether there should be different requirements based on the scope of a given maintainer.
+* Whether sponsorship by an existing maintainer is required.
+* How maintainers are proposed to the community. Proposals are typically done by creating PR against the `MAINTAINERS` file, and including information in the PR about how the proposed contributor meets the criteria to be a maintainer.
+* How many maintainers must approve the proposed maintainer. This should include information about what happens if someone vetoes the proposal.
+* How long the existing maintainers have to respond to the proposal.
 
 ## How Maintainers are Removed or Moved to Emeritus Status
-The `MAINTAINERS` file SHOULD contain information about how a maintainer is removed from the list of active maintainers. Information that SHOULD be included in this section:
 
-* What are the reasons a maintainer would be removed from the list of active maintainers
-* How this is proposed; similar to the way in which maintainers are added, one way to do this is via a PR against the `MAINTAINERS` file
-* How an emeritus maintainer becomes active again
+The `MAINTAINERS` file **SHOULD** contain information about how a maintainer is removed from the list of active maintainers. Information that **SHOULD** be included in this section:
 
-
-# Examples
-* [Hyperledger Besu](https://github.com/hyperledger/besu/blob/master/MAINTAINERS.md)
-* [Hyperledger Fabric](https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html#maintainers)
-* [Hyperledger Sawtooth](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0006-sawtooth-governance.md#contributor-permission-levels)
-* [Hyperledger Grid (same as Sawtooth)](https://github.com/hyperledger/grid-rfcs/blob/master/text/0008-grid-governance.md#contributor-permission-levels)
-* [Hyperledger Transact (same as Sawtooth)](https://github.com/hyperledger/transact-rfcs/blob/master/text/0000-transact-governance.md#contributor-permission-levels)
+* The reasons a maintainer would be removed from the list of active maintainers.
+* How a removal is proposed. Typically, this is similar to the way in which maintainers are added, such as via a PR against the `MAINTAINERS` file.
 
 # References
 * [TOC Decision Log - Common Maintainers Management Policy](https://wiki.hyperledger.org/display/TSC/Common+Maintainers+management+policy)

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -9,25 +9,34 @@ nav_order: 2
 
 ## Introduction
 
-All Hyperledger repositories **MUST** have a `MAINTAINERS` file (`MAINTAINERS.md` or `MAINTAINERS.rst`) at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](SAMPLE-MAINTAINERS.md) can be used as a template by projects creating a new repository.
+All Hyperledger repositories **MUST** have a `MAINTAINERS.md` file at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](SAMPLE-MAINTAINERS.md) can be used as a template by projects creating a new repository.
 
-The Hyperledger Foundation GitHub organization administrators **SHOULD** periodically send out notifications about missing `MAINTAINERS` files.
+The Hyperledger Foundation GitHub organization administrators **SHOULD** periodically send out notifications about missing `MAINTAINERS.md` files.
 
-The following provides guidelines and suggested content to include in the `MAINTAINERS` file.
+The following provides guidelines and suggested content to include in the `MAINTAINERS.md` file.
 
 ## Maintainer Scopes and GitHub Roles
 
-Becoming a Maintainer for a repository implies being granted special privileges within that repository to do the additional tasks required of a Maintainer. In most cases, the additional privileges are implemented
-by giving maintainers one of the elevated [GitHub roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization) within the repository.
+Becoming a Maintainer for a repository implies being granted special privileges
+within that repository to do the additional scope(s) of work required of a
+Maintainer. In most cases, the additional privileges are implemented by giving
+maintainers one of the elevated [GitHub
+roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization)
+within the repository.
 
-In most repositories, only the "Maintain" GitHub role is used. It is given to all repository Maintainers.
+In most repositories, the "Maintainer" scope is given to all repository
+Maintainers. The "Maintainer" scope is defined as the "Maintain" GitHub role.
+This is usually sufficient to do all of the work required of a Maintainer. From
+time to time, Maintainers may have to request certain administrative tasks by
+performed by the Hyperledger GitHub organization administrators.
 
-In some repositories, the maintainers may define a list of "scopes" and each Maintainer given one or more of the designated scopes:
+In some repositories, the maintainers may decide to define additional scopes and
+each Maintainer given one or more of those designated scopes:
 
 - In rare cases, Maintainers in a repository may request that the Hyperledger Foundation GitHub organization administrators enable designating some Maintainers with different GitHub roles, such as "Admin" (more capable than "Maintain") or "Triage" (less capable than "Maintain").
   - Each elevated GitHub role needed in a repository requires the Hyperledger Foundation GitHub organization administrators to create and maintain an additional GitHub Team.
   - The Hyperledger Foundation GitHub organization administrators manage a team per Hyperledger Project that includes all contributors to the project. That team is given the "Read" GitHub role in all project repositories. This team need not be documented in the "MAINTAINERS" file.
-- Maintainers **MAY** define Maintainers scope within a repository don't require
+- Maintainers **MAY** define Maintainer scopes within a repository that don't require
   elevated GitHub privileges. For example, a scope might include hosting
   community meetings, or contributing to the Hyperledger Project's Quarterly
   report.
@@ -36,15 +45,15 @@ If there is more than the single "Maintainer" scope used in a repository, there 
 
 | Scope | Definition | GitHub Role | GitHub Team |
 | ----- | ---------- | ----------- | ----------- |
-|       |            |             |             |
+| Maintainer | The GitHub Maintain role | Maintain   | `<repository> committers`     |
 
 ## List of Repository Maintainers
 
-Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINERS` file.
+Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINERS.md` file.
 
-Changes to the maintainers lists **MUST** be made via Pull Requests. Once a new `MAINTAINERS` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
+Changes to the maintainers lists **MUST** be made via Pull Requests. Once a new `MAINTAINERS.md` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
 
-It is recommended that the lists be sorted alphabetically and contain at least the maintainers name and GitHub ID. If useful, other columns may be added to the table, such as LFID, Discord ID, Email, and Company Affiliation.
+It is recommended that the lists be sorted alphabetically and contain at least the maintainer's name and GitHub ID, plus additional information about the Maintainer, including LFID (Linux Foundation ID), Discord ID, Email, and Company Affiliation.
 
 A "Scope" column **MUST** be included if there is more than one scope defined in the repository.
 
@@ -52,19 +61,19 @@ The following shows a suggested format for the information:
 
 **Active Maintainers**
 
-| Maintainer | GitHub ID | Scope |
-| ---------- | --------- | ----- |
-|            |           |       |
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
 
 **Emeritus Maintainers**
 
-| Maintainer | GitHub ID | Scope |
-| ---------- | --------- | ----- |
-|            |           |       |
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
 
-## What Does Being a Maintainer Entail
+## Maintainer Duties
 
-The `MAINTAINERS` file **SHOULD** contain information about the different
+The `MAINTAINERS.md` file **SHOULD** contain information about the different
 maintainer scopes, and for each, the maintainers duties (e.g., maintainers
 calls, quarterly reports, code reviews, issue cleansing). See the [Sample
 Maintainers](SAMPLE-MAINTAINERS.md) for an example of what to include in this
@@ -81,22 +90,22 @@ that reflect the agreement of the community, as opposed to code related metrics
 
 ## How to Become a Maintainer
 
-The `MAINTAINERS` file **SHOULD** contain information about how to become a maintainer for the project. This section **SHOULD** list specific information about what is required. Information that **SHOULD** be included in this section:
+The `MAINTAINERS.md` file **SHOULD** contain information about how to become a maintainer for the project. This section **SHOULD** list specific information about what is required. Information that **SHOULD** be included in this section:
 
 * What is required before someone can be considered to become a maintainer.
   * Include a statement on how an emeritus maintainer can be changed to active again.
 * Consider whether there should be different requirements based on the scope of a given maintainer.
 * Whether sponsorship by an existing maintainer is required.
-* How maintainers are proposed to the community. Proposals are typically done by creating PR against the `MAINTAINERS` file, and including information in the PR about how the proposed contributor meets the criteria to be a maintainer.
+* How maintainers are proposed to the community. Proposals are typically done by creating PR against the `MAINTAINERS.md` file, and including information in the PR about how the proposed contributor meets the criteria to be a maintainer.
 * How many maintainers must approve the proposed maintainer. This should include information about what happens if someone vetoes the proposal.
 * How long the existing maintainers have to respond to the proposal.
 
 ## How Maintainers are Removed or Moved to Emeritus Status
 
-The `MAINTAINERS` file **SHOULD** contain information about how a maintainer is removed from the list of active maintainers. Information that **SHOULD** be included in this section:
+The `MAINTAINERS.md` file **SHOULD** contain information about how a maintainer is removed from the list of active maintainers. Information that **SHOULD** be included in this section:
 
 * The reasons a maintainer would be removed from the list of active maintainers.
-* How a removal is proposed. Typically, this is similar to the way in which maintainers are added, such as via a PR against the `MAINTAINERS` file.
+* How a removal is proposed. Typically, this is similar to the way in which maintainers are added, such as via a PR against the `MAINTAINERS.md` file.
 
 # References
 * [TOC Decision Log - Common Maintainers Management Policy](https://wiki.hyperledger.org/display/TSC/Common+Maintainers+management+policy)

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -86,7 +86,7 @@ in such cases) might be different than for Maintainers of an open source code
 project. The Maintainer role is more about approving and merging pull requests
 that reflect the agreement of the community, as opposed to code related metrics
 (quality, fit for purpose, tests, etc.). In some cases, a GOVERNANCE.md file
-[like this](https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md) might further define the duties of the maintainers.
+like the [AnonCreds Methods Registry governance.md file](https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md) might further define the duties of the maintainers.
 
 ## How to Become a Maintainer
 

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -43,9 +43,9 @@ each Maintainer given one or more of those designated scopes:
 
 If there is more than the single "Maintainer" scope used in a repository, there **MUST** be a list of the repository specific scopes in the MAINTAINERS file. The list must include the scope name, the definition of the scope, and if applicable, the related GitHub Role and Team for the scope.
 
-| Scope | Definition | GitHub Role | GitHub Team |
-| ----- | ---------- | ----------- | ----------- |
-| Maintainer | The GitHub Maintain role | Maintain   | `<repository> committers`     |
+| Scope      | Definition               | GitHub Role | GitHub Team               |
+| ---------- | ------------------------ | ----------- | ------------------------- |
+| Maintainer | The GitHub Maintain role | Maintain    | `<repository> committers` |
 
 ## List of Repository Maintainers
 
@@ -53,22 +53,25 @@ Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINER
 
 Changes to the maintainers lists **MUST** be made via Pull Requests. Once a new `MAINTAINERS.md` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
 
-It is recommended that the lists be sorted alphabetically and contain at least the maintainer's name and GitHub ID, plus additional information about the Maintainer, including LFID (Linux Foundation ID), Discord ID, Email, and Company Affiliation.
+It is recommended that the lists be sorted alphabetically and **MUST** contain at least the Maintainers name, GitHub ID, Scope, and at least one contact method. The reasons for populating columns are:
 
-A "Scope" column **MUST** be included if there is more than one scope defined in the repository.
+- A GitHub ID **MUST** be provided to add the Maintainer to a GitHub Team, and to recognize the action the Maintainer takes in the repository.
+- The Scope **MUST** be provided to know the role of each Maintainer, and to know the GitHub Team to update when adding/removing Maintainers.
+- A LFID (Linux Foundation ID), Discord ID and/or Email are the most effective ways for the Hyperledger Foundation to contact the Maintainer when necessary.
+- A Company Affiliation is helpful for monitoring the diversity of the Maintainer community for a project.
 
-The following shows a suggested format for the information:
+The following table format **MUST** be used for both Maintainers lists (active and emeritus):
 
 **Active Maintainers**
 
 | Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
-|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+| ---- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
 |      |           |       |      |            |       |                     |
 
 **Emeritus Maintainers**
 
 | Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
-|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+| ---- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
 |      |           |       |      |            |       |                     |
 
 ## Maintainer Duties
@@ -86,18 +89,22 @@ in such cases) might be different than for Maintainers of an open source code
 project. The Maintainer role is more about approving and merging pull requests
 that reflect the agreement of the community, as opposed to code related metrics
 (quality, fit for purpose, tests, etc.). In some cases, a GOVERNANCE.md file
-like the [AnonCreds Methods Registry governance.md file](https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md) might further define the duties of the maintainers.
+like the [AnonCreds Methods Registry governance file] might further define the duties of the maintainers.
+
+[AnonCreds Methods Registry governance file]: https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md
 
 ## How to Become a Maintainer
 
-The `MAINTAINERS.md` file **SHOULD** contain information about how to become a maintainer for the project. This section **SHOULD** list specific information about what is required. Information that **SHOULD** be included in this section:
+The `MAINTAINERS.md` file **SHOULD** contain information about how to become a
+maintainer for the project. This section **SHOULD** list specific information
+about what is required. Information that **SHOULD** be included in this section:
 
 * What is required before someone can be considered to become a maintainer.
   * Include a statement on how an emeritus maintainer can be changed to active again.
 * Consider whether there should be different requirements based on the scope of a given maintainer.
 * Whether sponsorship by an existing maintainer is required.
 * How maintainers are proposed to the community. Proposals are typically done by creating PR against the `MAINTAINERS.md` file, and including information in the PR about how the proposed contributor meets the criteria to be a maintainer.
-* How many maintainers must approve the proposed maintainer. This should include information about what happens if someone vetoes the proposal.
+* How many maintainers must approve the proposed maintainer.
 * How long the existing maintainers have to respond to the proposal.
 
 ## How Maintainers are Removed or Moved to Emeritus Status

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 ## Introduction
 
-All Hyperledger repositories MUST have a `MAINTAINERS` file (`MAINTAINERS.md` or `MAINTAINERS.rst`) at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](SAMPLE-MAINTAINERS.md) can be used as a template by projects creating a new repository.
+All Hyperledger repositories **MUST** have a `MAINTAINERS` file (`MAINTAINERS.md` or `MAINTAINERS.rst`) at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](SAMPLE-MAINTAINERS.md) can be used as a template by projects creating a new repository.
 
 The Hyperledger Foundation GitHub organization administrators **SHOULD** periodically send out notifications about missing `MAINTAINERS` files.
 

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -42,7 +42,7 @@ If there is more than the single "Maintainer" scope used in a repository, there 
 
 Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINERS` file.
 
-Changes to the maintainers lists MUST be made via Pull Requests. Once a new `MAINTAINERS` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
+Changes to the maintainers lists **MUST** be made via Pull Requests. Once a new `MAINTAINERS` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
 
 It is recommended that the lists be sorted alphabetically and contain at least the maintainers name and GitHub ID. If useful, other columns may be added to the table, such as LFID, Discord ID, Email, and Company Affiliation.
 

--- a/guidelines/MAINTAINERS-guidelines.md
+++ b/guidelines/MAINTAINERS-guidelines.md
@@ -40,7 +40,7 @@ If there is more than the single "Maintainer" scope used in a repository, there 
 
 ## List of Repository Maintainers
 
-Lists of active and emeritus maintainers MUST be included in the `MAINTAINERS` file.
+Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINERS` file.
 
 Changes to the maintainers lists MUST be made via Pull Requests. Once a new `MAINTAINERS` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the Hyperledger GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
 

--- a/guidelines/SAMPLE-MAINTAINERS.md
+++ b/guidelines/SAMPLE-MAINTAINERS.md
@@ -1,0 +1,112 @@
+# Maintainers
+
+A sample MAINTAINERS.md file for a Hyperledger project repository. Feel free to
+copy this file into your repository and update it for your specific needs.
+
+## Maintainer Scopes, GitHub Roles and GitHub Teams
+
+The only Maintainer scope for this repository is `Maintainer`, which is given to all repository maintainers. The "Maintainer" scope uses the `Maintain` [GitHub Role](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization).
+
+The GitHub teams for this repository are:
+
+- Maintainer: [\<repo name> committers](#)
+
+## Active Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name             | Github           |
+| ---------------- | ---------------- |
+|                  |                  |
+
+## Emeritus Maintainers
+
+| Name             | Github           |
+| ---------------- | ---------------- |
+|                  |                  |
+
+## The Duties of a Maintainer
+
+Maintainers are expected to perform the following tasks for this repository. The tasks are listed in more or less priority order:
+
+- Review, provide feedback on, and merge or reject GitHub Pull Requests from
+  Contributors.
+- Review, triage, comment on, and, when appropriate, close GitHub Issues
+  submitted by Contributors.
+- When appropriate, lead/facilitate architectural discussions in the community.
+- When appropriate, lead/facilitate the creation of a product roadmap.
+- Ensure that there is a well defined (and ideally automated) product test and
+  release pipeline, including the publication of release artifacts.
+- When appropriate, execute the product release process.
+- Maintain the repository CONTRIBUTING.md file and getting started documents to
+  give guidance and encouragement to those wanting to contribute to the product, and those wanting to become maintainers.
+- Contribute to the product via GitHub Pull Requests.
+- Monitor requests from the Hyperledger Technical Oversight Committee about the
+contents and management of Hyperledger repositories, such as branch handling,
+required files in repositories and so on.
+- Contribute to the Hyperledger Project's Quarterly Report.
+
+## Becoming a Maintainer
+
+This community welcomes contributions. Interested contributors are encouraged to
+progress to become maintainers. To become a maintainer the following steps
+occur, roughly in order.
+
+- The proposed maintainer establishes their reputation in the community,
+  including authoring five (5) significant merged pull requests, and expresses
+  an interest in becoming a maintainer for the repository.
+- A PR is created to update this file to add the proposed maintainer to the list of active maintainers.
+- The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
+- The PR is authored by the proposed maintainer or has a comment on the PR from the proposed maintainer expressing their interest in being a maintainer.
+  - The PR or comment from the proposed maintainer must include their
+    willingness to be a long-term (more than 6 month) maintainer.
+- Once the PR and necessary comments have been received, an approval timeframe begins.
+- The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
+- An add maintainer PR may be vetoed by another maintainer prior to merging.
+  - Vetoes must be accompanied by a public explanation as a comment in the
+    PR.
+  - The explanation of the veto must be reasonable.
+  - A veto can be retracted. In that case the approval/veto timeframe is reset.
+  - It is bad form to veto, retract, and veto again.
+- The PR is merged and the proposed maintainer becomes a maintainer if
+  - No maintainer posts a veto AND
+    - Either: Two weeks have passed since at least 3 Maintainer PR approvals has been recorded, OR
+    - An absolute majority of maintainers have approved the PR.
+- Once the add maintainer PR has been merged, any necessary updates to the GitHub Teams are made.
+
+## Removing Maintainers
+
+Being a maintainer is not a status symbol or a title to be carried
+indefinitely. It will occasionally be necessary and appropriate to move a
+maintainer to emeritus status. This can occur in the following situations:
+
+- Resignation of a maintainer.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be no commits or code review comments
+    for one reporting quarter. This will not be strictly enforced if
+    the maintainer expresses a reasonable intent to continue contributing.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other circumstances at the discretion of the other Maintainers.
+
+The process to move a maintainer from active to emeritus status is comparable to the process for adding a maintainer, outlined above. In the case of voluntary
+resignation, the Pull Request can be merged following a maintainer PR approval. If the removal is for any other reason, the following steps **SHOULD** be followed:
+
+- A PR is created to update this file to move the maintainer to the list of emeritus maintainers.
+- The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
+- Once the PR and necessary comments have been received, the approval timeframe begins.
+- The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
+- The PR may be vetoed prior to merging by a maintainer other than the one to be removed.
+  - Vetoes must be accompanied by a public explanation of the veto.
+  - The explanation of the veto must be reasonable.
+  - A veto can be retracted. In that case the approval/veto timeframe is reset.
+  - It is bad form to veto, retract, and veto again.
+- The PR is merged and the maintainer transitions to maintainer emeritus if:
+  - No maintainer posts a veto AND
+    - Either: Two weeks have passed since the minimum number of PR approvals has been recorded, OR
+    - An absolute majority of maintainers have approved the PR.
+
+Returning to active status from emeritus status uses the same steps as adding a
+new maintainer. Note that the emeritus maintainer already has the 5 required
+significant changes as there is no contribution time horizon for those.

--- a/guidelines/SAMPLE-MAINTAINERS.md
+++ b/guidelines/SAMPLE-MAINTAINERS.md
@@ -1,7 +1,12 @@
 # Maintainers
 
-A sample MAINTAINERS.md file for a Hyperledger project repository. Feel free to
-copy this file into your repository and update it for your specific needs.
+This is a sample `MAINTAINERS.md` file for a Hyperledger project repository.
+Feel free to copy this file into your repository and update it for your specific
+needs.
+
+It is sufficient to have a `MAINTAINERS.md` file that contains only a reference to a `MAINTAINERS.md` file in another repository that is part of the Hyperledger project.  For example:
+
+> For information about the Maintainers of this repository, please see this Hyperledger \<PROJECT> repository's [MAINTAINERS](#) file.
 
 ## Maintainer Scopes, GitHub Roles and GitHub Teams
 
@@ -30,6 +35,7 @@ Maintainers are assigned the following scopes in this repository:
 
 Maintainers are expected to perform the following duties for this repository. The duties are listed in more or less priority order:
 
+- Review, respond, and act on an reported security vulnerabilities reported against the repository.
 - Review, provide feedback on, and merge or reject GitHub Pull Requests from
   Contributors.
 - Review, triage, comment on, and close GitHub Issues
@@ -59,21 +65,15 @@ occur, roughly in order.
   an interest in becoming a maintainer for the repository.
 - A PR is created to update this file to add the proposed maintainer to the list of active maintainers.
 - The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
-- The PR is authored by the proposed maintainer or has a comment on the PR from the proposed maintainer expressing their interest in being a maintainer.
+- The PR is authored by the proposed maintainer or has a comment on the PR from the proposed maintainer confirming their interest in being a maintainer.
   - The PR or comment from the proposed maintainer must include their
     willingness to be a long-term (more than 6 month) maintainer.
 - Once the PR and necessary comments have been received, an approval timeframe begins.
 - The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
-- An add maintainer PR may be vetoed by another maintainer prior to merging.
-  - Vetoes must be accompanied by a public explanation as a comment in the
-    PR.
-  - The explanation of the veto must be reasonable.
-  - A veto can be retracted. In that case the approval/veto timeframe is reset.
-  - It is bad form to veto, retract, and veto again.
-- The PR is merged and the proposed maintainer becomes a maintainer if
-  - No maintainer posts a veto AND
-    - Either: Two weeks have passed since at least 3 Maintainer PR approvals has been recorded, OR
-    - An absolute majority of maintainers have approved the PR.
+- The PR is merged and the proposed maintainer becomes a maintainer if either:
+  - Two weeks have passed since at least three (3) Maintainer PR approvals have been recorded, OR
+  - An absolute majority of maintainers have approved the PR.
+- If the PR does not get the requisite PR approvals, it may be closed.
 - Once the add maintainer PR has been merged, any necessary updates to the GitHub Teams are made.
 
 ## Removing Maintainers
@@ -99,15 +99,11 @@ resignation, the Pull Request can be merged following a maintainer PR approval. 
 - The PR is authored by, or has a comment supporting the proposal from, an existing maintainer or Hyperledger GitHub organization administrator.
 - Once the PR and necessary comments have been received, the approval timeframe begins.
 - The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
-- The PR may be vetoed prior to merging by a maintainer other than the one to be removed.
-  - Vetoes must be accompanied by a public explanation of the veto.
-  - The explanation of the veto must be reasonable.
-  - A veto can be retracted. In that case the approval/veto timeframe is reset.
-  - It is bad form to veto, retract, and veto again.
 - The PR is merged and the maintainer transitions to maintainer emeritus if:
-  - No maintainer posts a veto AND
-    - Either: Two weeks have passed since the minimum number of PR approvals has been recorded, OR
-    - An absolute majority of maintainers have approved the PR.
+  - The PR is approved by the maintainer to be transitioned, OR
+  - Two weeks have passed since at least three (3) Maintainer PR approvals have been recorded, OR
+  - An absolute majority of maintainers have approved the PR.
+- If the PR does not get the requisite PR approvals, it may be closed.
 
 Returning to active status from emeritus status uses the same steps as adding a
 new maintainer. Note that the emeritus maintainer already has the 5 required

--- a/guidelines/SAMPLE-MAINTAINERS.md
+++ b/guidelines/SAMPLE-MAINTAINERS.md
@@ -35,7 +35,7 @@ Maintainers are assigned the following scopes in this repository:
 
 Maintainers are expected to perform the following duties for this repository. The duties are listed in more or less priority order:
 
-- Review, respond, and act on an reported security vulnerabilities reported against the repository.
+- Review, respond, and act on any reported security vulnerabilities reported against the repository.
 - Review, provide feedback on, and merge or reject GitHub Pull Requests from
   Contributors.
 - Review, triage, comment on, and close GitHub Issues

--- a/guidelines/SAMPLE-MAINTAINERS.md
+++ b/guidelines/SAMPLE-MAINTAINERS.md
@@ -35,7 +35,7 @@ Maintainers are assigned the following scopes in this repository:
 
 Maintainers are expected to perform the following duties for this repository. The duties are listed in more or less priority order:
 
-- Review, respond, and act on any reported security vulnerabilities reported against the repository.
+- Review, respond, and act on any security vulnerabilities reported against the repository.
 - Review, provide feedback on, and merge or reject GitHub Pull Requests from
   Contributors.
 - Review, triage, comment on, and close GitHub Issues

--- a/guidelines/SAMPLE-MAINTAINERS.md
+++ b/guidelines/SAMPLE-MAINTAINERS.md
@@ -5,36 +5,38 @@ copy this file into your repository and update it for your specific needs.
 
 ## Maintainer Scopes, GitHub Roles and GitHub Teams
 
-The only Maintainer scope for this repository is `Maintainer`, which is given to all repository maintainers. The "Maintainer" scope uses the `Maintain` [GitHub Role](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization).
+Maintainers are assigned the following scopes in this repository:
 
-The GitHub teams for this repository are:
-
-- Maintainer: [\<repo name> committers](#)
+| Scope | Definition | GitHub Role | GitHub Team |
+| ----- | ---------- | ----------- | ----------- |
+| Maintainer | The GitHub Maintain role | Maintain   | `<repository> committers`     |
 
 ## Active Maintainers
 
 <!-- Please keep this sorted alphabetically by github -->
 
-| Name             | Github           |
-| ---------------- | ---------------- |
-|                  |                  |
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
 
 ## Emeritus Maintainers
 
-| Name             | Github           |
-| ---------------- | ---------------- |
-|                  |                  |
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
 
 ## The Duties of a Maintainer
 
-Maintainers are expected to perform the following tasks for this repository. The tasks are listed in more or less priority order:
+Maintainers are expected to perform the following duties for this repository. The duties are listed in more or less priority order:
 
 - Review, provide feedback on, and merge or reject GitHub Pull Requests from
   Contributors.
-- Review, triage, comment on, and, when appropriate, close GitHub Issues
+- Review, triage, comment on, and close GitHub Issues
   submitted by Contributors.
 - When appropriate, lead/facilitate architectural discussions in the community.
 - When appropriate, lead/facilitate the creation of a product roadmap.
+- Create, clarify, and label issues to be worked on by Contributors.
 - Ensure that there is a well defined (and ideally automated) product test and
   release pipeline, including the publication of release artifacts.
 - When appropriate, execute the product release process.
@@ -94,7 +96,7 @@ The process to move a maintainer from active to emeritus status is comparable to
 resignation, the Pull Request can be merged following a maintainer PR approval. If the removal is for any other reason, the following steps **SHOULD** be followed:
 
 - A PR is created to update this file to move the maintainer to the list of emeritus maintainers.
-- The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
+- The PR is authored by, or has a comment supporting the proposal from, an existing maintainer or Hyperledger GitHub organization administrator.
 - Once the PR and necessary comments have been received, the approval timeframe begins.
 - The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
 - The PR may be vetoed prior to merging by a maintainer other than the one to be removed.


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

Updates the maintainers guidance document and adds a `Sample MAINTAINERS.md` file.

- Acknowledges that a MAINTAINERS.md file applies to a repo vs. a project.
- Talks about scope in terms of GitHub roles, or unrelated to GitHub Roles.
- Provides a sample Maintainers file.
- In the Sample Maintainers file, provides a list of tasks for open source software repository maintainers.

While I think this clarifies the Maintainer process and meaning, a key contribution is the tasks of an open source maintainer.
