### PR TITLE
Proposed Hyperledger Security document and project Security Template

### DIFF
--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -62,8 +62,8 @@ the community or the public find bugs and report them to the project. A
 vulnerability disclosure policy explains how this process functions from the
 perspective of the project.
 
-This vulnerability disclosure policy explains the rules and guidelines for the
-Hyperledger PROJECT Project. It is intended to act as both a reference for
+This vulnerability disclosure policy explains the rules and guidelines for
+Hyperledger PROJECT. It is intended to act as both a reference for
 outsiders–including both bug reporters and those looking for information on the
 project’s security practices–as well as a set of rules that maintainers and
 contributors have agreed to follow.

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -1,0 +1,187 @@
+# Hyperledger PROJECT Security Policy
+
+## Instructions
+
+The following is the best practices template security vulnerability disclosure
+policy for Hyperledger projects or subprojects within individual Hyperledger
+projects. Please copy the text below, place it into the `SECURITY.md` file for
+the primary repository of your project, and adjust it as necessary for your
+project. Notably:
+
+* Remove this "Instructions" section.
+* Replace "PROJECT" throughout the document with the name of your project.
+
+Once your project's security vulnerability disclosure policy document is
+published, place a copy it into the rest of the repositories of your project, or
+create a `SECURITY.md` file in each repository that links back to the primary
+document.
+
+See the "**Alternative:**" notes in the [Hyperledger security vulnerability
+disclosure policy] document for how the "best practices" in this document can be
+changed to meet the needs of a specific project while still adhering to the
+Hyperledger policies.
+
+[Hyperledger security vulnerability disclosure policy]: /governing-documents/security.md
+
+## About this document
+
+This document defines how security vulnerability reporting is handled in the
+Hyperledger PROJECT project. The approach aligns with the [Hyperledger
+Foundation's Security Vulnerability Reporting
+policy](https://toc.hyperledger.org/governing-documents/security.html). Please
+review that document to understand the basis of the security reporting for
+Hyperledger PROJECT.
+
+The Hyperledger Security Vulnerability policy borrows heavily from the
+recommendations of the OpenSSF Vulnerability Disclosure working group. For
+up-to-date information on the latest recommendations related to vulnerability
+disclosures, please visit the [GitHub of that working
+group](https://github.com/ossf/wg-vulnerability-disclosures).
+
+If you are already familiar with the security policies of Hyperledger PROJECT, and
+ready to report a vulnerability, please jump to [Report
+Intakes](#report-intakes).
+
+## Outline
+
+This document has the following sections:
+
+1. [What is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
+2. [Security Team](#security-team)
+3. [Report Intakes](#report-intakes)
+4. [CNA/CVE Reporting](#cnacve-reporting)
+5. [Embargo List](#embargo-list)
+6. [(GitHub) Security Advisories](#github-security-advisories)
+7. [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
+
+### What Is a Vulnerability Disclosure Policy?
+
+No piece of software is perfect. All software (at least, all software of a
+certain size and complexity) has bugs. In open source development, members of
+the community or the public find bugs and report them to the project. A
+vulnerability disclosure policy explains how this process functions from the
+perspective of the project.
+
+This vulnerability disclosure policy explains the rules and guidelines for the
+Hyperledger PROJECT Project. It is intended to act as both a reference for
+outsiders–including both bug reporters and those looking for information on the
+project’s security practices–as well as a set of rules that maintainers and
+contributors have agreed to follow.
+
+### Security Team
+
+The current Hyperledger PROJECT security team is:
+
+| Name             | Email ID           | Discord ID | Area/Specialty  |
+| ---------------- | ------------------ | ---------- | --------------- |
+| Satoshi Nakamoto | satoshi@nsa.gov    |            | Everything      |
+| Hart Montgomery  | hart@donotmail.com |            | Else            |
+| <>               | <>                 | <>         | (if applicable) |
+
+The security team for Hyperledger PROJECT must include at least three project
+Maintainers that agree to carry out the following duties and responsibilities.
+Members are added and removed from the team via approved Pull Requests to this
+repository. For additional background into the role of the security team, see
+the [People Infrastructure] section of the Hyperledger Security Policy.
+
+[People Infrastructure]: https://toc.hyperledger.org/governing-documents/security.html#people-infrastructure
+
+**Responsibilities:**
+
+1. Acknowledge the receipt of vulnerability reports to the reporter within 2
+   business days.
+
+2. Assess the issue. Engage with the reporter to ask any outstanding questions
+about the report and how to reproduce it. If the report was received by email
+and may be a security vulnerability, open a GitHub Security Advisory on the
+repository to manage the report. If the report is not considered a
+vulnerability, then the reporter should be informed and this process can be
+halted. If the report is a regular bug (but not a security vulnerability), the
+reporter should be informed (if necessary) of the regular process for reporting
+issues.
+
+3. Some issues may require more time and resources to correct. If a particular
+report is complex, discuss an embargo period with the reporter during which
+time the report will not be publicly disclosed. The embargo period should be
+negotiated with the reporter and must not be longer than 90 days.
+
+4. If necessary, create a private patch development infrastructure for the issue
+   by email the [Hyperledger Community Architects].
+
+[Hyperledger Community Architects]: mailto:community-architects@hyperledger.org
+
+5. Request a CVE for the issue (see the [CNA/CVE Reporting](#cnacve-reporting)
+   section).
+
+6. Decide a date for the public release of the vulnerability report, the date
+   the embargo period ends.
+
+7. If applicable, notify members of the embargo list of the vulnerability,
+upcoming patch and release, as described above.
+
+8. Publish a new (software) release in which the vulnerability is addressed.
+
+9. Publicly disclose the issue within 48 hours after the release via a
+GitHub security advisory (see the [(GitHub) Security
+Advisories](#github-security-advisories) section for details).
+
+### Discussion Forums
+
+Discussions about each reported vulnerability should be carried out in the
+private GitHub security advisory about the vulnerability. If necessary, a private
+channel specific to the issue may be created on the Hyperledger Discord server
+with invited participants added to the discussion.
+
+### Report Intakes
+
+The Hyperledger PROJECT project has the following ways to submit security
+vulnerabilities. While the security team members will do their best to
+respond to bugs disclosed in all possible ways, it is encouraged for bug
+finders to report through the following approved channels:
+
+- Email the [Hyperledger Foundation security
+list](mailto:security@lists.hyperledger.org): To report a security issue, please
+send an email with the name of the project/repository, a description of the issue, the
+steps you took to create the issue, affected versions, and if known,
+mitigations. If in triaging the email, the security team determines the issue may be
+a security vulnerability, a [GitHub security vulnerability report] will be
+opened.
+- Open a [GitHub security vulnerability report]: Open a draft security advisory
+on the "Security" tab of this GitHub repository. See [GitHub Security
+Advisories](#github-security-advisories) to learn more about the security
+infrastructure in GitHub.
+
+[GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+
+### CNA/CVE Reporting
+
+Hyperledger PROJECT maintains a list of **Common Vulnerabilities and Exposures
+(CVE)** and uses GitHub as its **CVE numbering authority (CNA)** for issuing
+CVEs.
+
+### Embargo List
+
+The Hyperledger PROJECT project maintains a private embargo list. If you wish to
+be added to the embargo list, please email the [Hyperledger Foundation security
+mailing list](mailto:security@lists.hyperledger.org), including the project name
+(Hyperledger PROJECT) and reason for being added to the embargo list. Requests
+will be assessed by the Hyperledger PROJECT security team in conjunction with the
+appropriate Hyperledger Staff, and a decision will be made to accommodate or not
+the request.
+
+For more information about the embargo list, please see the [Embargo List
+section of the Hyperledger Security
+Policy](https://toc.hyperledger.org/governing-documents/security.html#embargo-list).
+
+### (GitHub) Security Advisories
+
+Hyperledger PROJECT uses GitHub Security Advisories to manage the public
+disclosure of security vulnerabilities.
+
+### Private Patch Deployment Infrastructure
+
+In creating patches and new releases that address security vulnerabilities,
+Hyperledger PROJECT uses the private development features of GitHub for security
+vulnerabilities. GitHub has [extensive
+documentation](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories)
+about these features.

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -12,7 +12,7 @@ project. Notably:
 * Replace "PROJECT" throughout the document with the name of your project.
 
 Once your project's security vulnerability disclosure policy document is
-published, place a copy it into the rest of the repositories of your project, or
+published, place a copy of it into the rest of the repositories of your project, or
 create a `SECURITY.md` file in each repository that links back to the primary
 document.
 

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -161,7 +161,7 @@ CVEs.
 
 ### Embargo List
 
-The Hyperledger PROJECT project maintains a private embargo list. If you wish to
+Hyperledger PROJECT maintains a private embargo list. If you wish to
 be added to the embargo list, please email the [Hyperledger Foundation security
 mailing list](mailto:security@lists.hyperledger.org), including the project name
 (Hyperledger PROJECT) and reason for being added to the embargo list. Requests

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -134,7 +134,7 @@ with invited participants added to the discussion.
 
 ### Report Intakes
 
-The Hyperledger PROJECT project has the following ways to submit security
+Hyperledger PROJECT has the following ways to submit security
 vulnerabilities. While the security team members will do their best to
 respond to bugs disclosed in all possible ways, it is encouraged for bug
 finders to report through the following approved channels:

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -46,15 +46,20 @@ Intakes](#report-intakes).
 
 This document has the following sections:
 
-1. [What is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
-2. [Security Team](#security-team)
-3. [Report Intakes](#report-intakes)
-4. [CNA/CVE Reporting](#cnacve-reporting)
-5. [Embargo List](#embargo-list)
-6. [(GitHub) Security Advisories](#github-security-advisories)
-7. [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
+- [Hyperledger PROJECT Security Policy](#hyperledger-project-security-policy)
+  - [Instructions](#instructions)
+  - [About this document](#about-this-document)
+  - [Outline](#outline)
+  - [What Is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
+  - [Security Team](#security-team)
+  - [Discussion Forums](#discussion-forums)
+  - [Report Intakes](#report-intakes)
+  - [CNA/CVE Reporting](#cnacve-reporting)
+  - [Embargo List](#embargo-list)
+  - [(GitHub) Security Advisories](#github-security-advisories)
+  - [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
 
-### What Is a Vulnerability Disclosure Policy?
+## What Is a Vulnerability Disclosure Policy?
 
 No piece of software is perfect. All software (at least, all software of a
 certain size and complexity) has bugs. In open source development, members of
@@ -68,7 +73,7 @@ outsiders–including both bug reporters and those looking for information on th
 project’s security practices–as well as a set of rules that maintainers and
 contributors have agreed to follow.
 
-### Security Team
+## Security Team
 
 The current Hyperledger PROJECT security team is:
 
@@ -125,14 +130,14 @@ upcoming patch and release, as described above.
 GitHub security advisory (see the [(GitHub) Security
 Advisories](#github-security-advisories) section for details).
 
-### Discussion Forums
+## Discussion Forums
 
 Discussions about each reported vulnerability should be carried out in the
 private GitHub security advisory about the vulnerability. If necessary, a private
 channel specific to the issue may be created on the Hyperledger Discord server
 with invited participants added to the discussion.
 
-### Report Intakes
+## Report Intakes
 
 Hyperledger PROJECT has the following ways to submit security
 vulnerabilities. While the security team members will do their best to
@@ -153,13 +158,13 @@ infrastructure in GitHub.
 
 [GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
-### CNA/CVE Reporting
+## CNA/CVE Reporting
 
 Hyperledger PROJECT maintains a list of **Common Vulnerabilities and Exposures
 (CVE)** and uses GitHub as its **CVE numbering authority (CNA)** for issuing
 CVEs.
 
-### Embargo List
+## Embargo List
 
 Hyperledger PROJECT maintains a private embargo list. If you wish to
 be added to the embargo list, please email the [Hyperledger Foundation security
@@ -173,12 +178,12 @@ For more information about the embargo list, please see the [Embargo List
 section of the Hyperledger Security
 Policy](https://toc.hyperledger.org/governing-documents/security.html#embargo-list).
 
-### (GitHub) Security Advisories
+## (GitHub) Security Advisories
 
 Hyperledger PROJECT uses GitHub Security Advisories to manage the public
 disclosure of security vulnerabilities.
 
-### Private Patch Deployment Infrastructure
+## Private Patch Deployment Infrastructure
 
 In creating patches and new releases that address security vulnerabilities,
 Hyperledger PROJECT uses the private development features of GitHub for security

--- a/governing-documents/security-template.md
+++ b/governing-documents/security-template.md
@@ -106,7 +106,7 @@ time the report will not be publicly disclosed. The embargo period should be
 negotiated with the reporter and must not be longer than 90 days.
 
 4. If necessary, create a private patch development infrastructure for the issue
-   by email the [Hyperledger Community Architects].
+   by emailing the [Hyperledger Community Architects].
 
 [Hyperledger Community Architects]: mailto:community-architects@hyperledger.org
 

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -22,7 +22,7 @@ disclosure policy.
 
 All project repositories **MUST** have a published security vulnerability disclosure
 policy or have link to a common policy document for the project. In rare cases,
-a repository within a project may have a policy different from the project, as
+a repository within a project **MAY** have a policy different from the project, as
 long as the repository policy also adheres to this Hyperledger security
 vulnerability disclosure policy.
 

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -182,7 +182,7 @@ infrastructure in GitHub.
 
 [GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
-**Alternative:** Projects may publish in their security policy that they accept
+**Alternative:** Projects **MAY** publish in their security policy that they accept
 security vulnerability disclosures via other mechanism, such as using the
 [HackerOne.com] service. The policy must document the necessary details in using
 the alternate reporting mechanism(s). In addition, a project may publish that

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -119,7 +119,7 @@ This section details the required basic vulnerability disclosure infrastructure
 for all Hyperledger projects. There are quite a few necessary pieces of infrastructure,
 and we go through them in detail here.
 
-**Security team:** Projects must have a security response team of at
+**Security team:** Projects **MUST** have a security response team of at
 least three maintainers. This response team shall be set up BEFORE incidents
 happen so that people know who to contact and how to contact them when an
 emergency issue arises. It can be difficult to track down someone with unique

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -153,7 +153,7 @@ team members in the following format.
 
 Discussions about each reported vulnerability **SHOULD** be carried out in the
 private GitHub security advisory about the vulnerability. If necessary, a private
-channel specific to the issue may be created on the Hyperledger Discord server
+channel specific to the issue **MAY** be created on the Hyperledger Discord server
 with invited participants added to the discussion.
 
 **Alternative:** Projects **MAY** document on their security policy that they use other forums for private discussion forums for approved maintainers and

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -185,7 +185,7 @@ infrastructure in GitHub.
 **Alternative:** Projects **MAY** publish in their security policy that they accept
 security vulnerability disclosures via other mechanism, such as using the
 [HackerOne.com] service. The policy **MUST** document the necessary details in using
-the alternate reporting mechanism(s). In addition, a project may publish that
+the alternate reporting mechanism(s). In addition, a project **MAY** publish that
 they don't accept reports via the recommended GitHub security vulnerability
 process. Projects **MUST** accept reports via the [Hyperledger Foundation
 security list].

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -151,7 +151,7 @@ team members in the following format.
 
 **Discussion forum:**
 
-Discussions about each reported vulnerability should be carried out in the
+Discussions about each reported vulnerability **SHOULD** be carried out in the
 private GitHub security advisory about the vulnerability. If necessary, a private
 channel specific to the issue may be created on the Hyperledger Discord server
 with invited participants added to the discussion.

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -247,7 +247,7 @@ assessed by the respective Hyperledger security team in conjunction with the
 appropriate Hyperledger Staff, and a decision will be made to accommodate or not
 the request.
 
-**Alternative:** Projects may choose to document in their security document
+**Alternative:** Projects **MAY** choose to document in their security document
 that they do not have an embargo list. The reason for not having an embargo list
 **SHOULD** be included when a project chooses not to have an embargo list.
 

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -20,7 +20,7 @@ disclosure policy.
 
 [security-template.md]: /governing-documents/security-template.md
 
-All project repositories MUST have a published security vulnerability disclosure
+All project repositories **MUST** have a published security vulnerability disclosure
 policy or have link to a common policy document for the project. In rare cases,
 a repository within a project may have a policy different from the project, as
 long as the repository policy also adheres to this Hyperledger security

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -157,7 +157,7 @@ channel specific to the issue **MAY** be created on the Hyperledger Discord serv
 with invited participants added to the discussion.
 
 **Alternative:** Projects **MAY** document on their security policy that they use other forums for private discussion forums for approved maintainers and
-security team participants to discuss vulnerabilities. Details about the other forum(s) must be included.
+security team participants to discuss vulnerabilities. If other forum(s) are used, details about them **MUST** be included.
 
 ## Report Intakes
 

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -1,0 +1,281 @@
+---
+layout: default
+title:  Security Policy
+parent: Governing Documents
+grand_parent: Hyperledger TOC
+nav_order: 10
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+This document outlines the Hyperledger security vulnerability disclosure policy
+that all Hyperledger projects **MUST** follow. The associated
+[security-template.md] file is a "best practices" security vulnerability
+disclosure policy that project Maintainers **SHOULD** use for
+publishing the security policy and procedures for their project by copying the
+file into their project repositories and updating it according to the
+instructions in the document. This document includes the "best practices" text,
+and defines how project Maintainers can use alternatives to the best practices for their project. A project's resulting
+alternative policy **MUST** adhere to the Hyperledger security vulnerability
+disclosure policy.
+
+[security-template.md]: /governing-documents/security-template.md
+
+All project repositories MUST have a published security vulnerability disclosure
+policy or have link to a common policy document for the project. In rare cases,
+a repository within a project may have a policy different from the project, as
+long as the repository policy also adheres to this Hyperledger security
+vulnerability disclosure policy.
+
+## About This Document
+
+This policy borrows heavily from the recommendations of the OpenSSF
+Vulnerability Disclosure working group. For up-to-date information on the latest
+recommendations related to vulnerability disclosures, please visit the [GitHub
+of that working group](https://github.com/ossf/wg-vulnerability-disclosures).
+
+## Outline:
+
+This document has the following sections:
+
+1. [What is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
+2. [Vulnerability Disclosure Processes and Associated Rules](#vulnerability-disclosure-process-and-associated-rules)
+3. [“People” Infrastructure](#people-infrastructure)
+4. [Report Intakes](#report-intakes)
+5. [CNA/CVE Reporting](#cnacve-reporting)
+6. [Embargo List](#embargo-list)
+7. [(GitHub) Security Advisories](#github-security-advisories)
+8. [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
+
+In each of these sections, and in the associated [security-template.md], the
+current Hyperledger "best practices" are defined. In some sections are
+alternatives (tagged "**Alternative:**") that projects may want to use. When
+projects vary from the current Hyperledger best practices, the documented alternatives
+**MUST** adhere to this policy.
+
+## What Is a Vulnerability Disclosure Policy?
+
+No piece of software is perfect. All software (at least, all software of a
+certain size and complexity) has bugs. In open source development, members of
+the community or the public find bugs and report them to the project. A
+vulnerability disclosure policy explains how this process functions from the
+perspective of the project.
+
+This vulnerability disclosure policy explains the rules and guidelines for
+Hyperledger Projects. It is intended to act as both a reference for
+outsiders–including both bug reporters and those looking for information on the
+project’s security practices–as well as a set of rules that maintainers and
+contributors have agreed to follow.
+
+## Vulnerability Disclosure Process and Associated Rules
+
+All Hyperledger projects, including this project, follow the associated process
+and rules for vulnerability disclosures. We note that this outline is derived
+from the [OpenSSF maintainers guide](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md).
+
+Each project will have a security team (for more details, see the
+[people infrastructure](#people-infrastructure) below). The security team
+will be comprised of maintainers or contributors to the project who are
+knowledgeable about security and is responsible for responding to and
+helping to fix security vulnerabilities.
+
+The security team (see [people infrastructure](#people-infrastructure) for
+details) for this project will do the following for each reported vulnerability:
+
+1. Acknowledge receipt (see [Report Intakes](#report-intakes) for more) of the
+issue to the reporter within 2 business days.
+
+2. Assess the issue. Engage with the reporter to ask any outstanding questions
+about the report and how to reproduce it. If the report is not considered a
+vulnerability, then the reporter should be informed and this process can be
+halted. If the report is still a regular bug (just not a security
+vulnerability), the reporter should be informed (if necessary) of the regular
+process for reporting bugs.
+
+3. Some issues may require more time and resources to correct. If a
+particular report is more complex, discuss an embargo period with the reporter.
+The embargo period should be negotiated with the reporter and must not be
+longer than 90 days.
+
+4. Create a patch for the issue (see the [Private Patch Deployment
+Infrastructure](#private-patch-deployment-infrastructure) section).
+
+5. Request a CVE for the issue (see the [CNA/CVE Reporting](#cnacve-reporting) section).
+
+6. Decide the date of public release.
+
+7. If applicable, notify members of the embargo list of the upcoming patch
+and release, as described above.
+
+8. Cut a new (software) release in which the bug is fixed..
+
+9. Publicly disclose the issue within 48 hours after the release. It is
+recommended that this is done through GitHub security advisories (see the
+[(GitHub) Security Advisories](#github-security-advisories) section for
+more details).
+
+## “People” Infrastructure
+
+This section details the required basic vulnerability disclosure infrastructure
+for all Hyperledger projects. There are quite a few necessary pieces of infrastructure,
+and we go through them in detail here.
+
+**Security team:** Projects must have a security response team of at
+least three maintainers. This response team shall be set up BEFORE incidents
+happen so that people know who to contact and how to contact them when an
+emergency issue arises. It can be difficult to track down someone with unique
+knowledge (e.g. in a particular area of cryptography) who is capable of
+fixing a problem in a short period of time.
+
+1. Each security team member will be a member of the
+[Hyperledger Foundation security email list](mailto:security@lists.hyperledger.org),
+and, in general, any Hyperledger-wide security infrastructure.
+
+2. If a project has specialized code related to certain aspects of security
+or cryptography (e.g. consensus algorithms or cryptographic algorithms), then
+a corresponding specialist should be on the response team (e.g. someone
+knowledgeable in consensus or cryptography, respectively). If a specialist
+is not on the team, then the individual who is responsible for contacting or
+engaging the specialists should be designated in their stead. We emphasize
+that projects should have access to specialists in an area for which they
+maintain code while recognizing that it may not be practical for these experts
+to be on the response team.
+
+Each project/repository must have a table in the security document listing the
+team members in the following format.
+
+| Name             | Email ID           | Chat ID        | Area/Specialty  |
+| ---------------- | ------------------ | -------------- | --------------- |
+| Satoshi Nakamoto | satoshi@nsa.gov    | theREALsatoshi | Everything      |
+| Hart Montgomery  | hart@donotmail.com | uselessIDIOT   | Nothing         |
+| <>               | <>                 | <>             | (if applicable) |
+
+**Discussion forum:**
+
+Discussions about each reported vulnerability should be carried out in the
+private GitHub security advisory about the vulnerability. If necessary, a private
+channel specific to the issue may be created on the Hyperledger Discord server
+with invited participants added to the discussion.
+
+**Alternative:** Projects may document on their security policy that they use other forums for private discussion forums for approved maintainers and
+security team participants to discuss vulnerabilities. Details about the other forum(s) must be included.
+
+## Report Intakes
+
+Hyperledger projects offer the following ways to submit security
+vulnerabilities. While the security team members will do their best to
+respond to bugs disclosed in all possible ways, it is encouraged for bug
+finders to report through the following approved channels:
+
+- Email the [Hyperledger Foundation security
+list]: To report a security issue, please
+send an email with the name of the project/repository, a description of the issue, the
+steps you took to create the issue, affected versions, and if known,
+mitigations. If in triaging the email, the security team determines the issue may be
+a security vulnerability, a [GitHub security vulnerability report] will be
+opened.
+- Open a [GitHub security vulnerability report]: Open a draft security advisory
+on the "Security" tab of this GitHub repository. See [GitHub Security
+Advisories](#github-security-advisories) to learn more about the security
+infrastructure in GitHub.
+
+[Hyperledger Foundation security list]: mailto:security@lists.hyperledger.org
+
+[GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+
+**Alternative:** Projects may publish in their security policy that they accept
+security vulnerability disclosures via other mechanism, such as using the
+[HackerOne.com] service. The policy must document the necessary details in using
+the alternate reporting mechanism(s). In addition, a project may publish that
+they don't accept reports via the recommended GitHub security vulnerability
+process. Projects **MUST** accept reports via the [Hyperledger Foundation
+security list].
+
+[HackerOne.com]: https://www.hackerone.com/
+
+## CNA/CVE Reporting
+
+Hyperledger projects maintain a list of **Common Vulnerabilities and Exposures
+(CVE)** and use GitHub as its **CVE numbering authority (CNA)** for issuing
+CVEs.
+
+**Alternative:** A project **MAY** document in its security policy that it uses
+a different CVE numbering authority. For example, the project might add the
+following text to this section of their security policy document:
+
+```
+This project uses the following CNA(s) in the following situations:
+1. `CNA_1`:  `situation_1, can just state “default” if only one CNA`
+2. `CNA_2`:  `situation_2`
+```
+
+## Embargo List
+
+An embargo list is a list of known, trusted entities that run
+large deployments of a given Hyperledger project. These
+entities are notified ahead of time when important security patches are
+incoming to minimize potential security risks to large deployments of
+projects. Embargo lists are maintained by the security team for a given project/repository.
+
+Parties are on an embargo list for (usually) one of two reasons,
+because they can either help fix the problem (perhaps through testing a fix at
+scale) or they need extra time to help prepare their ecosystem to roll out
+fixes quickly. Approval is not given lightly: project leadership
+(maintainers) must be convinced that institutions on the list **“need to know"**
+about issues in advance.
+
+Participation in an embargo list should not be taken lightly. List members
+are expected to respect the materials shared through it and not disclose any
+information to unauthorized parties until the public disclosure date.
+Institutions are on this list because their presence helps the project and its
+users; if their actions do not help the project and its users, they can expect
+to be removed from the list.
+
+The list itself is private in order to make it slightly more difficult for
+attackers with vulnerabilities to find systems to attack. Entities may be
+added to the embargo list by a majority vote of the `project` security response
+team and should request to join the embargo list by contacting one or more of
+the members of the security response team. If there is an issue about embargo
+list membership where an entity feels like they are being dealt with unfairly
+by the security response team, then they are encouraged to bring up the issue
+in front of the Hyperledger TOC, who can act as moderators.
+
+Hyperledger projects maintain private embargo lists. If you wish to be added to
+the embargo list for a project, please email the [Hyperledger Foundation
+security list], including the
+project name and reason for being added to the embargo list. Requests will be
+assessed by the respective Hyperledger security team in conjunction with the
+appropriate Hyperledger Staff, and a decision will be made to accommodate or not
+the request.
+
+**Alternative:** Projects may choose to document in their security document
+that they do not have an embargo list. The reason for not having an embargo list
+**SHOULD** be included when a project chooses not to have an embargo list.
+
+## (GitHub) Security Advisories
+
+Hyperledger Foundation projects use [GitHub
+security advisories and the GitHub security process](https://docs.github.com/en/code-security/security-advisories) for
+handling security vulnerabilities. In particular, this best practice is strongly recommended
+for projects that do not have a large number of security experts as the
+features serve as a nice set of **guardrails** to help make sure that things are
+done correctly.
+
+**Alternative:** Projects **MAY** document in their security policy document
+that they use a security advisory mechanism other than GitHub to publish their
+disclosures. The alternate mechanism must be documented sufficiently for users
+to understand how to monitor the security advisories published by the project.
+
+## Private Patch Deployment Infrastructure
+
+Patches to fix Hyperledger project security vulnerabilities are typically
+developed without public visibility by using the private development features of
+GitHub. Projects with maintainers that are not familiar with these capabilities
+are encouraged to contact the [Hyperledger Community Architects] to learn more.
+
+[Hyperledger Community Architects]: community-architects@hyperledger.org
+
+**Alternative:** Projects **MAY** document in their security policy document
+that they do use a service other than GitHub for private patch deployment
+infrastructure, or that they don't use any private patch deployment
+infrastructure at all. In either case, the document **MUST** include the details
+of what is used instead.

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -156,7 +156,7 @@ private GitHub security advisory about the vulnerability. If necessary, a privat
 channel specific to the issue may be created on the Hyperledger Discord server
 with invited participants added to the discussion.
 
-**Alternative:** Projects may document on their security policy that they use other forums for private discussion forums for approved maintainers and
+**Alternative:** Projects **MAY** document on their security policy that they use other forums for private discussion forums for approved maintainers and
 security team participants to discuss vulnerabilities. Details about the other forum(s) must be included.
 
 ## Report Intakes

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -262,7 +262,7 @@ done correctly.
 
 **Alternative:** Projects **MAY** document in their security policy document
 that they use a security advisory mechanism other than GitHub to publish their
-disclosures. The alternate mechanism must be documented sufficiently for users
+disclosures. The alternate mechanism **MUST** be documented sufficiently for users
 to understand how to monitor the security advisories published by the project.
 
 ## Private Patch Deployment Infrastructure

--- a/governing-documents/security.md
+++ b/governing-documents/security.md
@@ -184,7 +184,7 @@ infrastructure in GitHub.
 
 **Alternative:** Projects **MAY** publish in their security policy that they accept
 security vulnerability disclosures via other mechanism, such as using the
-[HackerOne.com] service. The policy must document the necessary details in using
+[HackerOne.com] service. The policy **MUST** document the necessary details in using
 the alternate reporting mechanism(s). In addition, a project may publish that
 they don't accept reports via the recommended GitHub security vulnerability
 process. Projects **MUST** accept reports via the [Hyperledger Foundation


### PR DESCRIPTION
Per discussion, this puts the Hyperledger security vulnerability disclosure policy into the Security document, and adds a "security-template.md" for Projects to use in creating their project- (or repository-) specific document. 

As noted, the Hyperledger Policy is not a template, but explains the policy and requirements, and outlines the best practices. In appropriate places, an **Alternative:** tag is used to define what options a project has from the best practices.  The template, on the other hand is just that -- and can usually simply be copied from the template, pasted into a project `SECURITY.md` file, and updated per the instructions (\<tl;dr\> remove instructions, update "PROJECT" to the project name).  Since all of the alternatives are in the primary document, they are not included in the template at all.

Hope that works.  I tried not to change any of the intent of the document, just the arrangement of the words :-).

Enjoy!



Signed-off-by: Stephen Curran <swcurran@gmail.com>
