### PR TITLE
build(devcontainer): enable local development via jekyll serve

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
+{
+	"name": "Jekyll",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"installDirectlyFromGitHubRelease": true,
+			"version": "2.50.0"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "jekyll --version"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+
+source 'https://rubygems.org'
+
+gem "rake"
+gem "jekyll"
+gem "jekyll-remote-theme"
+gem "jekyll-seo-tag"
+gem "jekyll-include-cache"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,87 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.1)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.16.3)
+    forwardable-extended (2.6.0)
+    google-protobuf (3.25.3-x86_64-linux)
+    http_parser.rb (0.8.0)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (5.0.5)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rouge (4.2.1)
+    rubyzip (2.3.2)
+    safe_yaml (1.0.5)
+    sass-embedded (1.62.1-x86_64-linux-gnu)
+      google-protobuf (~> 3.21)
+    strscan (3.1.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.5.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  x86_64-linux-gnu
+
+DEPENDENCIES
+  jekyll
+  jekyll-include-cache
+  jekyll-remote-theme
+  jekyll-seo-tag
+  rake
+
+BUNDLED WITH
+   2.5.11

--- a/_config.yml
+++ b/_config.yml
@@ -18,3 +18,5 @@ aux_links:
     - "//wiki.hyperledger.org/display/TSC/Technical+Oversight+Committee+Home"
   "Chat":
     - "https://discord.gg/hyperledger/"
+plugins:
+  - jekyll-remote-theme


### PR DESCRIPTION
1. Added a VSCode dev container definition that contains Ruby and Jekyll
2. Declared the gem dependencies so that `bundle install` can be used to
install the build dependencies which then enable `jekyll serve` to locally
host and render the themed version of the TOC website.
3. This will unlock easier modification to the theme which is a pre-condition
of being able to debug CSS/theme/styling changes such as the width issues
I discovered recently on the new project dashboard page where the last few
columns are cut off from the view.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>