### PR TITLE
27th June 2024 TOC meeting minutes

### DIFF
--- a/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
+++ b/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
@@ -42,14 +42,14 @@ Hyperledger is committed to creating a safe and welcoming community for all. For
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Stephen Curran
+- [x] Marcus Brandenburger
+- [x] Stephen Curran
 - [ ] ~~David Enyeart~~
 - [ ] ~~Tracy Kuhrt~~
-- [ ] Yacov Manevich
-- [ ] Matt Nelson
-- [ ] Venkatraman Ramakrishna
-- [ ] Arun S M
-- [ ] Peter Somogyvari
-- [ ] Conor Svensson
-- [ ] Jim Zhang
+- [x] Yacov Manevich
+- [ ] ~~Matt Nelson~~
+- [x] Venkatraman Ramakrishna
+- [x] Arun S M
+- [ ] ~~Peter Somogyvari~~
+- [x] Conor Svensson
+- [x] Jim Zhang

--- a/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
+++ b/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
@@ -13,6 +13,7 @@ Hyperledger is committed to creating a safe and welcoming community for all. For
 
 # Announcements
 - The [Hyperledger /dev/weekly developer newsletter](https://wiki.hyperledger.org/pages/viewpage.action?pageId=39618905) goes out each Friday to hundreds of Hyperledger developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://wiki.hyperledger.org/display/DR/2024)
+- In recognition of the growing market for and adoption of decentralized technologies, the Linux Foundation announced plans to form [LF Decentralized Trust](https://www.linuxfoundation.org/press/linux-foundation-announces-intent-to-form-lf-decentralized-trust).
 - Reminder: The July 4th, 2024 meeting is canceled.
 
 # Quarterly reports
@@ -21,6 +22,7 @@ Hyperledger is committed to creating a safe and welcoming community for all. For
 - 2024 Q2 Hyperledger Besu (due June 20, 2024)
 - 2024 Q2 Hyperledger Caliper (due June 20, 2024)
 - Please review any [outstanding quarterly reports](https://github.com/hyperledger/toc/pulls?q=is%3Apr+is%3Aopen+label%3Aquarterly-report+user-review-requested%3A%40me).
+- Hyperledger Labs Q2 Report
 
 # Upcoming reports
 - 2024 Q3 Hyperledger Cacti (due July 11, 2024)
@@ -42,7 +44,7 @@ Hyperledger is committed to creating a safe and welcoming community for all. For
 
 - [ ] Marcus Brandenburger
 - [ ] Stephen Curran
-- [ ] David Enyeart
+- [ ] ~~David Enyeart~~
 - [ ] ~~Tracy Kuhrt~~
 - [ ] Yacov Manevich
 - [ ] Matt Nelson

--- a/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
+++ b/meeting-minutes/2024/2024-06-27-TOC-meeting-record.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: 2024-06-27 TOC Meeting Record
+parent: 2024
+grand_parent: Meeting Minutes
+nav_exclude: true
+---
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the Hyperledger Community](../images/all-are-welcome.png "All are Welcome in the Hyperledger Community")
+
+Hyperledger is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [Hyperledger Code of Conduct](https://toc.hyperledger.org/governing-documents/code-of-conduct.html)
+
+# Announcements
+- The [Hyperledger /dev/weekly developer newsletter](https://wiki.hyperledger.org/pages/viewpage.action?pageId=39618905) goes out each Friday to hundreds of Hyperledger developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://wiki.hyperledger.org/display/DR/2024)
+- Reminder: The July 4th, 2024 meeting is canceled.
+
+# Quarterly reports
+- [2024 Q2 Hyperledger Firefly](https://github.com/hyperledger/toc/pull/262)
+- [2024 Q2 Hyperledger Solang](https://github.com/hyperledger/toc/pull/263)
+- 2024 Q2 Hyperledger Besu (due June 20, 2024)
+- 2024 Q2 Hyperledger Caliper (due June 20, 2024)
+- Please review any [outstanding quarterly reports](https://github.com/hyperledger/toc/pulls?q=is%3Apr+is%3Aopen+label%3Aquarterly-report+user-review-requested%3A%40me).
+
+# Upcoming reports
+- 2024 Q3 Hyperledger Cacti (due July 11, 2024)
+- 2024 Q3 Hyperledger Fabric (due July 11, 2024)
+- 2024 Q3 Hyperledger Identus (due July 11, 2024)
+- 2024 Q3 Hyperledger Web3j (due July 11, 2024)
+- [2024 TOC Project Update Calendar](../../project-reports/2024/2024-updates.md)
+
+# Discussion
+- Task force discussion: Security Artifact Signing
+
+# Recordings
+- [Recordings are available on the Hyperledger calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/hyp)
+
+# Upcoming TOC meetings
+[Please check the calendar](https://lists.hyperledger.org/g/toc/calendar)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Stephen Curran
+- [ ] David Enyeart
+- [ ] ~~Tracy Kuhrt~~
+- [ ] Yacov Manevich
+- [ ] Matt Nelson
+- [ ] Venkatraman Ramakrishna
+- [ ] Arun S M
+- [ ] Peter Somogyvari
+- [ ] Conor Svensson
+- [ ] Jim Zhang


### PR DESCRIPTION
- Set the agenda: including announcements, quarterly project reviews, task force discussions
- Mark the TOC attendance