### PR TITLE
Updates to the annual review governance document and template for LFDT

### DIFF
--- a/governing-documents/project-annual-review.md
+++ b/governing-documents/project-annual-review.md
@@ -10,81 +10,89 @@ nav_order: 5
 # Project Annual Review
 
 ## Overview
+
 In addition to the [quarterly project updates](./project-updates.md), projects will undergo an annual review by the TAC. This annual review will replace one of the quarterly reports. Unlike the quarterly updates, the annual review process will be a "big picture" assessment of the project by reviewing the progress on goals from the prior year and goals for the next year. In addition, the annual review process will include a deep dive into the project health, including contributor and maintainer diversity and adoption metrics, and will include an assessment of the current [project lifecycle state](./project-lifecycle.md). The review will result in a set of recommendations for the project to improve and/or recommendation to move a project to another stage.
 
 ## Timeline
-Annual reviews will replace the Q1 quarterly report.  **If your annual review is not submitted within two months of notification, we will take this as a sign that the project is not under active maintenance and the TAC is likely to decide to archive the project and move it to End of Life status.**
 
-**NOTE:** If a project has genuinely stalled we can save everyone’s time and effort by archiving the project and moving it to `End of Life`.
+Annual reviews will replace the Q1 quarterly report.  **If a project's annual review is not submitted within two months of notification, the TAC will take this as a sign that the project is not under active maintenance and is likely to decide to archive the project and move it to End of Life status.**
+
+**NOTE:** If a project has genuinely stalled the project's TSC can save everyone’s time and effort by archiving the project and moving it to `End of Life`.
 
 ## Process
+
 The process for annual reviews is as follows:
 
-* A TAC representative will be chosen on a round-robin basis to lead the review once the project files a PR. This representative should be someone that is not directly involved with the project.
-* A secondary representative will be chosen on a round-robin basis to observe and corroborate the findings of the lead. This representative should be someone that is not directly involved with the project.
-* The lead TAC member reviews the content of the PR and analyzes the project for community health indicators, their findings are placed within a thread in the TAC channel ([#toc](https://discord.com/channels/905194001349627914/941384040316018790)) for discussion. The thread should contain:
-    1. important facts about the project that could influence the TACs decision around the future of the project, its current stage, and path to other stages.
-    2. whether the project's view of themselves is accurate and the ask of the TAC is reasonable to assist the project moving forward.
-* The lead TAC member will work closely with the secondary TAC member to review their findings prior to the TAC meeting.
-* The project's maintainers are invited to the public TAC meeting to engage in TAC-led discussion around the project. Project maintainers are not obligated to attend, but it is highly recommended.
-* The lead TAC member provides a summary of the project and leverages the thread's content as the basis of discussion. The discussion typically focuses on what is going well with the project and areas to improve.
-* The project's maintainers are invited to use this time to voice any concerns and requests for help they may have that are not captured in the PR (or highlight asks within the PR).
-* At the conclusion of the public meeting, the TAC votes to approve the annual review. Should a concern be registered on a project, the vote will be held separately.
-* After the meeting wraps up, the lead TAC member should summarize the discussion on the PR in the form of a comment to document information for the project and community.
+- A TAC representative will be chosen on a round-robin basis to lead the review once the project files a PR. This representative should be someone that is not directly involved with the project.
+- A secondary representative will be chosen on a round-robin basis to observe and corroborate the findings of the lead. This representative should be someone that is not directly involved with the project.
+- The lead and secondary TAC members review the content of the PR, analyze the project for community health indicators, and place their findings into a thread in the TAC channel (**LINK TBD:** `#tac`) for discussion.
+- The project's TSC and advocates are invited to the public TAC meeting to engage in a TAC-led discussion about the project. Project TSC members are not obligated to attend, but it is highly recommended.
+- The lead TAC member provides a summary of the project and leverages the thread's content as the basis of discussion. The discussion typically focuses on what is going well with the project and areas to improve.
+- The project's TSC and contributors are invited to use this time to voice any concerns and requests for help they may have that are not captured in the PR (or highlight asks within the PR).
+- At the conclusion of the public meeting, the TAC votes to approve the annual review, including any change in the project's status. Should a concern be registered on a project, the vote will be held at a later date.
+- After the meeting wraps up, the lead TAC member should summarize the discussion on the PR in the form of a comment to document information for the project and community.
 
 ### Filing an Annual Review
-Hyperledger Foundation staff will notify the project maintainers and copy the TAC when the project review is due. 
 
-Project maintainers are responsible for agreeing between them who will complete the annual review. One of the maintainers should create the review in GitHub under [hyperledger/toc/project-reports/](https://github.com/hyperledger/toc/tree/gh-pages/project-reports).
+LF Decentralized Trust staff will notify the project TSC and copy the TAC when the project review is due.
 
-* Raise a PR titled *[year] [Project Name] Annual Review* (e.g., 2024 Hyperledger Amazing Annual Review)
-* The PR should include a file called `./<year>/<year>-annual-<Project-Name>.md` (e.g., `2024/2024-annual-Hyperledger-Amazing.md`) using [the annual review template](../project-reports/0000-annual-review-template.md)
-    - Update the information at the top of the file:
-        - change the `title` line to `YYY Annual Review Project Name` (e.g., `title: 2024 Annual Review Hyperledger Amazing`)
-        - change the `parent` line to `YYYY` (e.g., `parent: 2024`)
-        - change the `grand_parent` to `Project Updates` (i.e., `grand_parent: Project Updates`)
-        - remove the `nav_exclude` line
-    - Text between `<mark></mark>` are instructions. Please remove when section has been completed.
-* Send an email to the [TAC mailing list](mailto:toc@lists.hyperledger.org) so that the community knows the PR is there and can comment on it.
+Project TSC members are responsible for agreeing between them who will complete the annual review. One of the project's TSC members should create the review in GitHub under [lf-decentralized-trust/tac/project-reports/](https://github.com/lf-decentralized-trust/tac/tree/gh-pages/project-reports).
+
+- Raise a PR titled *`[year] [Project Name] Annual Review`* (e.g., `2024 LFDT Amazing Annual Review`).
+- The PR should include a file called `./<year>/<year>-annual-<Project-Name>.md` (e.g., `2024/2024-annual-lfdt-amazing.md`) using [the annual review template](../project-reports/0000-annual-review-template.md).
+  - Update the information at the top of the file:
+    - change the `title` line to `YYY Annual Review Project Name` (e.g., `title: 2024 Annual Review Hyperledger Amazing`)
+    - change the `parent` line to `YYYY` (e.g., `parent: 2024`)
+    - change the `grand_parent` to `Project Updates` (i.e., `grand_parent: Project Updates`)
+    - remove the `nav_exclude` line
+  - Text between `<mark></mark>` are instructions. Please remove when section has been completed.
+- Send an email to the **LINK TBD** `TAC mailing list` so that the community knows the PR is there and can comment on it.
 
 ## Potential Outcomes
+
 The outcome of the annual review is:
 
-* A majority of the TAC members agree to continue the project at its current stage, or
-* A majority of the TAC members recommend that a project be moved to a new stage, including `End of Life`, or
-* If the TAC cannot come to a consensus, the project will remain at its current stage.
+- A majority of the TAC members agree to continue the project at its current status, or
+- A majority of the TAC members recommend that a project be moved to a new status, including `End of Life`, or
+- If the TAC cannot come to a consensus, the project will remain at its current status.
 
-NOTE: If the TAC members recommend moving to a new stage, additional work may be required to provide details on how the project meets the new stage's acceptance criteria.
+NOTE: If the TAC members recommend moving to a new status, additional work may be required to provide details on how the project meets the new status's acceptance criteria.
 
 ## Roles and Responsibilities
 
-### Hyperledger Staff
+### LF Decentralized Trust Staff
 
-- Maintaining the calendar for the project annual reviews
-- Notifying the project maintainers and copying the TAC when the project review is due
+- Maintaining the calendar for the project annual reviews.
+- Notifying the project TSC and copying the TAC when the project review is due.
 
-### Project Maintainers
-- Agreeing between themselves who will complete the annual review and informing the TAC of who will be completing the report
-- Creating the annual review by filing a PR in GitHub under [hyperledger/toc/project-reports/](https://github.com/hyperledger/toc/tree/gh-pages/project-reports)
-- Sending email to the [TAC mailing list](mailto:toc@lists.hyperledger.org) so that the community knows the PR is there and can comment on it
-- Optionally attending the public TAC meeting to engage in TAC-led discussion around the project. The project's maintainers are invited to use this time to voice any concerns and requests for help they may have that are not captured in the PR (or highlight asks within the PR)
+### Project TSC
+
+- Agreeing between themselves who will complete the annual review.
+- Informing the community about the annual review and requesting input.
+- Creating the annual review by filing a PR in GitHub under [lf-decentralized-trust/tac/project-reports/](https://github.com/lf-decentralized-trust/tac/tree/gh-pages/project-reports).
+- Sending email to the [TAC mailing list](mailto:tac@lists.lf-decentralized-trust.org) and to the project community so that the community knows the PR is there and can comment on it.
+- Optionally attending the public TAC meeting to engage in TAC-led discussion around the project. The project's TSC members are invited to use this time to voice any concerns and requests for help they may have that are not captured in the PR (or highlight asks within the PR).
 
 ### TAC Member Responsible for Project's Annual Review
-- Reviewing the contents of the PR and analyzing the project's community health indicators
-- Documenting findings within a thread in the TAC channel ([#toc](https://discord.com/channels/905194001349627914/941384040316018790)) for discussion. The thread should contain:
-    1. Highlight important facts about the project that could influence the TAC's decision around the future of the project, its current stage, and paths to other stages
-    2. Whether the project's view of themselves is accurate and the ask of the TAC is reasonable to assist the project moving forward
-- Working closely with the secondary TAC member to review their findings prior to the TAC meeting
-- During the TAC-led discussion, providing a summary of the project and leverages the private thread's content as the basis of discussion. The discussion typically focuses on what is going well with the project and areas to improve
-- After the public meeting wraps up, summarizing the discussion on the PR in the form of a comment to document information for the project and community
+
+- Reviewing the contents of the PR and analyzing the project's community health indicators.
+- Coordinating with the secondary TAC member on their findings prior to the TAC meeting.
+- Documenting their findings within a thread in the TAC channel (TBD `#tac`) for discussion. The thread should contain:
+    1. Important facts about the project that could influence the TAC's decision around the future of the project, its current status, and paths to other statuses.
+    2. Whether the project's view of themselves is accurate and the ask of the TAC is reasonable to assist the project moving forward.
+- Lead the annual review discussion at the TAC meeting, providing a summary of the project by leveraging the private thread's content as the basis of discussion. The discussion typically focuses on what is going well with the project and areas to improve.
+- After the public meeting wraps up, summarizing the discussion on the PR in the form of a comment to document information for the project and community.
 
 ### TAC Secondary Member
-- Working closely with the lead TAC member to review and corroborate their findings
+
+- Working closely with the lead TAC member to review thew project's annual report, and to corroborate and publish their findings.
 
 ### TAC Members
-- Participating in the thread and asking questions that they might have
-- Participating in the TAC-led discussion of the project's annual review
-- Participating in the vote on the project's annual review
+
+- Participating in the thread and asking questions that they might have.
+- Participating in the TAC-led discussion of the project's annual review.
+- Participating in the vote on the project's annual review.
 
 ## Credits
+
 Ideas were taken from [CNCF's Sandbox Annual Review Process](https://github.com/cncf/toc/blob/main/process/) and the [OpenWallet Foundation's Annual Review Process](https://openwallet-foundation.github.io/tac/governance/project-annual-review-process/).

--- a/project-reports/0000-annual-review-template.md
+++ b/project-reports/0000-annual-review-template.md
@@ -6,36 +6,43 @@ grand_parent: LF Decentralized Trust TAC
 nav_exclude: true
 ---
 
-<mark>_Copy this template to the subdirectory for the current year and name the file `YYYY-annual-Project-Name.md` (e.g., `2024-annual-Hyperledger-Amazing.md`). Update the information above to change the `title` to the `YYYY Annual Review Project Name` (e.g., `2024 Annual Review Hyperledger Amazing`), the `parent` to `YYYY` (e.g., 2024), the `grand_parent` to `Project Updates`, and remove the `nav_exclude` line. Text between `<mark></mark>` are instructions. Please remove when section has been completed._
+<mark>_Copy this template to the subdirectory for the current year and name the file `YYYY-annual-Project-Name.md` (e.g., `2024-annual-lf-decentralized-trust-amazing.md`). Update the information above to change the `title` to the `YYYY Annual Review Project Name` (e.g., `2024 Annual Review LF Decentralized Trust Amazing`), the `parent` to `YYYY` (e.g., 2024), the `grand_parent` to `Project Updates`, and remove the `nav_exclude` line. Text between `<mark></mark>` are instructions. Please remove when section has been completed._
 </mark>
 
-# Project Health
-<mark>_Include a link to your project’s [LFX Insights page](https://insights-v2.lfx.linuxfoundation.org/projects). We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add color to the numbers and graphs we will see on Insights._
+## Project Health
+
+<mark>_Include a link to your project’s [LFX Insights page](https://insights-v2.lfx.linuxfoundation.org/projects). We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add color to the numbers and graphs we will see on Insights.
 </mark>
 
-# Maintainer Diversity
-<mark>_How many maintainers do you have, and which organisations are they from? How has the maintainers and diversity of your maintainers changed in the past year? Has the number of active maintainers increased/decreased? Has the diversity of maintainers increased/decreased? Please include a link to your existing [MAINTAINERS file](../guidelines/MAINTAINERS-guidelines.md) and the MAINTAINERS file from last year (if appropriate). This is a good opportunity to ensure that your MAINTAINERS file is up to date and to retire any maintainers._ 
+## Maintainer Diversity
+
+<mark>_How many maintainers do you have, and which organizations are they from? How has the maintainers and diversity of your maintainers changed in the past year? Has the number of active maintainers increased/decreased? Has the diversity of maintainers increased/decreased? Please include a link to your existing [MAINTAINERS file](../guidelines/MAINTAINERS-guidelines.md) and the MAINTAINERS file from last year (if appropriate). This is a good opportunity to ensure that your MAINTAINERS file is up to date and to retire any maintainers._
 </mark>
 
-# Project Adoption
-<mark>_What do you know about adoption, and how has this changed since your last review or since being accepted into Hyperledger Foundation? If you can list companies that are adopters of your project, please do so. Feel free to link to an existing ADOPTERS file if appropriate._
+## Project Adoption
+
+<mark>_What do you know about adoption, and how has this changed since your last review or since being accepted into LF Decentralized Trust? If you can list companies that are adopters of your project, please do so. Feel free to link to an existing ADOPTERS file if appropriate._
 </mark>
 
-# Goals
+## Goals
 
-## Performance Against Prior Goals
-<mark>_Include information about the goals that you previously set for the project in the last review or since the project proposal has been approved. How has the project performed against these goals? If your goals changed from your previous annual report, let us know what changed and why. If you have not achieved the goals that you set out, that is okay. We want to know what you have accomplished and what challenges the project is having in meeting the goals._
+### Performance Against Prior Goals
+
+<mark>_Include information about the goals that you previously set for the project in the last annual review or since the project proposal has been approved. How has the project performed against these goals? If your goals changed from your previous annual report, let us know what changed and why. If you have not achieved the goals that you set out, that is okay. We want to know what you have accomplished and what challenges the project is having in meeting the goals._
 </mark>
 
-## Next Year's Goals
+### Next Year's Goals
+
 <mark>_What are the goals for the next year of the project? The goals should list what you want to achieve, not just what you know you can achieve. Feel free to include stretch goals and things that you are looking to explore in the next year. For example, are you working on major new features? Or are you concentrating on adoption, community growth, or documentation?_
 </mark>
 
-## Help Required
-<mark>_How can the Hyperledger Foundation or the TAC help you achieve your upcoming goals?_
+### Help Required
+
+<mark>_How can the LF Decentralized Trust or the TAC help you achieve your upcoming goals?_
 </mark>
 
-# Project Lifecycle Stage Recommendation
-<mark>_What stage do you think the project should be? If you you think that your project meets the criteria for another stage, please explain why. (See [Project Lifecycle](../governing-documents/project-lifecycle.md))_
+## Project Lifecycle Status Recommendation
+
+<mark>_What status do you think the project should be? If you you think that your project meets the criteria for another status, please explain why. (See [Project Lifecycle](../governing-documents/project-lifecycle.md))_
 
 </mark>


### PR DESCRIPTION
Replaces PR #289 that was incorrectly handled in GitHub.  Some review of the PR was done in #289 and the comments made there have been addressed in this PR.

Per that PR, changes made include:

- Hyperledger references to LFDT
- lifecycle "stage" references --> "status" to be consistent with the Lifecycle document
- Change some references to Maintainers to TSC, where appropriate.
- Added "TBD Link" for a couple of links that are TBD (e.g., Discord channel).  Other links were updated and will likely be correct, but a link checker should be used on the published site to find invalid links.
- Fixed Markdown lint warnings
- General text cleanup