### PR TITLE
Added Q3 2024 Web3j Report

### DIFF
--- a/project-reports/2024/2024-Q2-Hyperledger-Web3j.md
+++ b/project-reports/2024/2024-Q2-Hyperledger-Web3j.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: 2024 Q2 Hyperledger Web3j
+parent: 2024
+grand_parent: Project Updates
+---
+
+# Project Health
+
+- The project is in good health.
+- We did 15 releases for all the Web3j Repos fixing several bugs, issues, vulnerabilities and adding new features. 
+- Upgraded Gradle to 8.7 and updated all the dependencies.
+- Fixed and simplified Web3j release process.
+- We got 2 Mentees involved in Web3j-android project through Hyperledger Mentorship Program.
+- Set up a fortnightly contributors call.
+
+# Questions/Issues for the TOC
+
+None at the moment.
+
+# Releases
+
+We did release several strong releases for all Web3j repos.
+
+- Web3j Core
+  - v4.9.8-hotfix for android (April 18, 2024)
+  - v4.11.3 (May 1, 2024)
+  - v4.12.0 (May 23, 2024)
+  
+- Web3j Gradle Plugin
+  - v4.11.3
+  - v4.11.3-hotfix
+  - v4.12.0
+  
+- Web3j Maven Plugin
+  - v4.11.3
+  
+- Web3j Unit
+  - v4.11.3
+  - v4.12.0
+
+- Web3j EVM
+    - v4.11.3
+    - v4.12.0
+
+- Web3j Sokt
+    - v0.4.0
+
+- Web3j Solidity Gradle Plugin
+    - v0.4.1
+    - v0.5.0
+
+- Web3j CLI
+    - v1.6.0
+
+# Overall Activity in the Past Quarter
+
+- 100+ commits and 30 PRs merged in Web3j core.
+- 50+ commits and 34 PRs merged across all other Web3j repositories.
+- Fixed bugs, issues, and vulnerabilities, and updated Java and Kotlin versions.
+- Simplified and fixed the release process of Web3j after migrating to the Hyperledger GitHub organization.
+- Upgraded to Gradle 8.7 and updated all dependencies. [Check Announcement](https://medium.com/web3labs/boost-dev-efficiency-security-with-web3js-gradle-8-7-upgrade-d8435a9fb990).
+- Hyperledger Mentorship Program - Mentees started working on web3j-android. [Check project roadmap](https://wiki.hyperledger.org/display/INTERN/Project+Plan+-+Hyperledger+Web3j%3A+Enhancing+Android+Support+with+Updated+web3j-android+Integration).
+- Set up a fortnightly contributors call. A few people joined the call, but it is not very successful yet.
+- The Discord channel was active with questions and announcements of new releases.
+
+# Current Plans
+
+- Fixing Bugs and issues in Web3j.
+- Getting web3j-android fixed for newer Android versions.
+- Adding support for account abstraction in Web3j.
+
+# Maintainer Diversity
+
+- No new maintainers were added this quarter, but several contributors remained active and showed interest towards maintainership.
+- Added guidelines for becoming a [maintainer](https://github.com/hyperledger/web3j/blob/main/MAINTAINERS.md).
+
+# Contributor Diversity
+
+- 6 new contributors in Web3j releases.
+- Contribution from Quant Labs to support decoding of dynamic structs.
+
+# Additional Information
+
+N/A
+

--- a/project-reports/2024/2024-Q3-Hyperledger-Web3j.md
+++ b/project-reports/2024/2024-Q3-Hyperledger-Web3j.md
@@ -8,11 +8,11 @@ grand_parent: Project Updates
 # Project Health
 
 - The project is in good health.
-- We did 15 releases for all the Web3j Repos fixing several bugs, issues, vulnerabilities and adding new features. 
-- Upgraded Gradle to 8.7 and updated all the dependencies.
-- Fixed and simplified Web3j release process.
-- We got 2 Mentees involved in Web3j-android project through Hyperledger Mentorship Program.
-- Set up a fortnightly contributors call.
+- We did 11 releases for all the Web3j Repos fixing several bugs, issues, vulnerabilities, licenses and adding new features.
+- Added steps and guidelines on how to become a Web3j maintainer.
+- Mentee Shashank is actively working on Web3j-android project through Hyperledger Mentorship Program.
+- Regularly having fortnightly contributors call.
+- Added Web3j [Roadmap](https://lf-hyperledger.atlassian.net/wiki/spaces/WEB3J/pages/23101932/Roadmap+2024+-+2025).
 
 # Questions/Issues for the TOC
 
@@ -23,45 +23,42 @@ None at the moment.
 We did release several strong releases for all Web3j repos.
 
 - Web3j Core
-  - v4.9.8-hotfix for android (April 18, 2024)
-  - v4.11.3 (May 1, 2024)
-  - v4.12.0 (May 23, 2024)
+  - v4.12.1 (Aug 14, 2024)
+  - v4.12.2 (Sept 18, 2024)
   
 - Web3j Gradle Plugin
-  - v4.11.3
-  - v4.11.3-hotfix
-  - v4.12.0
+  - v4.12.1 (Aug 16, 2024)
+  - v4.12.2 (Sept 19, 2024)
   
 - Web3j Maven Plugin
-  - v4.11.3
+  - v4.12.1 (Aug 16, 2024)
   
 - Web3j Unit
-  - v4.11.3
-  - v4.12.0
+  - v4.12.1 (Aug 15, 2024)
+  - v4.12.2 (Sept 18, 2024)
 
 - Web3j EVM
-    - v4.11.3
-    - v4.12.0
-
-- Web3j Sokt
-    - v0.4.0
+  - v4.12.1 (Aug 15, 2024)
+  - v4.12.2 (Sept 18, 2024)
 
 - Web3j Solidity Gradle Plugin
-    - v0.4.1
-    - v0.5.0
+    - v0.5.1 (Aug 16, 2024)
 
 - Web3j CLI
-    - v1.6.0
+    - v1.6.1 (Aug 17, 2024)
 
 # Overall Activity in the Past Quarter
 
-- 100+ commits and 30 PRs merged in Web3j core.
-- 50+ commits and 34 PRs merged across all other Web3j repositories.
-- Fixed bugs, issues, and vulnerabilities, and updated Java and Kotlin versions.
-- Simplified and fixed the release process of Web3j after migrating to the Hyperledger GitHub organization.
-- Upgraded to Gradle 8.7 and updated all dependencies. [Check Announcement](https://medium.com/web3labs/boost-dev-efficiency-security-with-web3js-gradle-8-7-upgrade-d8435a9fb990).
-- Hyperledger Mentorship Program - Mentees started working on web3j-android. [Check project roadmap](https://wiki.hyperledger.org/display/INTERN/Project+Plan+-+Hyperledger+Web3j%3A+Enhancing+Android+Support+with+Updated+web3j-android+Integration).
-- Set up a fortnightly contributors call. A few people joined the call, but it is not very successful yet.
+- 33 commits and 10 PRs merged in Web3j core.
+- 50+ commits and 18 PRs merged across all other Web3j repositories.
+- Fixed bugs, issues, and vulnerabilities, and updated dependencies.
+- Fixed licenses issue with some files in Web3j-repos.
+- Added support for Linea ENS.
+- Hyperledger Mentorship Program - 
+  - Mentee actively contributing to new Web3j-android [branch](https://github.com/shashankiitbhu/web3j/tree/web3j-android).
+  - Converted Web3j core to an android project and added android based configs. Resolving build issues.
+  - Tested Web3j functionalities in an android project.
+- Regularly having fortnightly contributors call. A few people joined the call, but it is not very successful yet.
 - The Discord channel was active with questions and announcements of new releases.
 
 # Current Plans
@@ -69,16 +66,17 @@ We did release several strong releases for all Web3j repos.
 - Fixing Bugs and issues in Web3j.
 - Getting web3j-android fixed for newer Android versions.
 - Adding support for account abstraction in Web3j.
+- Fix Web3j open-api project.
+- Organize Web3j Summit in early December.
 
 # Maintainer Diversity
 
 - No new maintainers were added this quarter, but several contributors remained active and showed interest towards maintainership.
-- Added guidelines for becoming a [maintainer](https://github.com/hyperledger/web3j/blob/main/MAINTAINERS.md).
 
 # Contributor Diversity
 
-- 6 new contributors in Web3j releases.
-- Contribution from Quant Labs to support decoding of dynamic structs.
+- 7 new contributors in Web3j releases.
+- Contributions from NTT to fix several bugs in Web3j.
 
 # Additional Information
 


### PR DESCRIPTION
Added Q3 2024 report for Hyperledger Web3j
Also I think last report was supposed to be Q2 which wrongly got posted under Q3, so changed the name of that file to Q2